### PR TITLE
Stagger pin labels in staircase layout

### DIFF
--- a/pinout_design/js/svg-renderer.js
+++ b/pinout_design/js/svg-renderer.js
@@ -227,22 +227,30 @@ export function renderConnectorSVG(connector, connType) {
   let maxName = 3;
   for (const p of pins) { if (p.name.length > maxName) maxName = p.name.length; }
   const charW = 0.6;
-  let fontSize = 6.0;
-  if (nPerRow > 1 && maxName > 0) {
-    fontSize = Math.min(fontSize, geo.pin_pitch * 0.9 / (maxName * charW));
-  }
-  fontSize = Math.round(Math.max(3.5, fontSize) * 10) / 10;
+  const fontSize = 6.0;
   const textH = fontSize + 3;
   const maxTextW = maxName * fontSize * charW + 4;
 
-  const effSides = new Set([r1Eff]);
-  if (r2Global.length) effSides.add(r2Eff);
-  const maxLine = Math.max(r1Line, r2Line);
+  // Give every label on a side its own level. Dense connectors previously put
+  // all labels on one baseline and shrank the type until it fitted between the
+  // pins, which made it easy to associate a label with the wrong pin.
+  const sideCounts = Object.fromEntries(sides.map((side) => [side, 0]));
+  const labelSteps = new Map();
+  for (let i = 0; i < n; i++) {
+    const [, rowNum] = pinMap.get(i);
+    const eff = rowNum === 2 ? r2Eff : r1Eff;
+    labelSteps.set(i, sideCounts[eff]);
+    sideCounts[eff] += 1;
+  }
 
   const pad = {};
   for (const s of sides) pad[s] = margin;
-  for (const s of effSides) {
-    pad[s] = maxLine + ((s === "bottom" || s === "top") ? textH : maxTextW);
+  for (let i = 0; i < n; i++) {
+    const [, rowNum] = pinMap.get(i);
+    const eff = rowNum === 2 ? r2Eff : r1Eff;
+    const ll = rowNum === 2 ? r2Line : r1Line;
+    const labelExtent = (eff === "bottom" || eff === "top") ? textH : maxTextW;
+    pad[eff] = Math.max(pad[eff], ll + labelSteps.get(i) * textH + labelExtent);
   }
 
   const svgW = pad["left"] + rotW + pad["right"];
@@ -288,13 +296,14 @@ export function renderConnectorSVG(connector, connType) {
     const [, rowNum] = pinMap.get(i);
     const eff = rowNum === 2 ? r2Eff : r1Eff;
     const ll = rowNum === 2 ? r2Line : r1Line;
+    const stairOffset = labelSteps.get(i) * textH;
     const [rpx, rpy] = pinPos(i);
     const col = pins[i].color;
     let lx2, ly2;
-    if (eff === "bottom")     { lx2 = rpx; ly2 = bodyBot + ll; }
-    else if (eff === "top")   { lx2 = rpx; ly2 = bodyTop - ll; }
-    else if (eff === "right") { lx2 = bodyRgt + ll; ly2 = rpy; }
-    else                      { lx2 = bodyLft - ll; ly2 = rpy; }
+    if (eff === "bottom")     { lx2 = rpx; ly2 = bodyBot + ll + stairOffset; }
+    else if (eff === "top")   { lx2 = rpx; ly2 = bodyTop - ll - stairOffset; }
+    else if (eff === "right") { lx2 = bodyRgt + ll + stairOffset; ly2 = rpy; }
+    else                      { lx2 = bodyLft - ll - stairOffset; ly2 = rpy; }
     parts.push(
       `<line x1="${f1(rpx)}" y1="${f1(rpy)}" ` +
       `x2="${f1(lx2)}" y2="${f1(ly2)}" ` +
@@ -361,6 +370,7 @@ export function renderConnectorSVG(connector, connType) {
     const [, rowNum] = pinMap.get(i);
     const eff = rowNum === 2 ? r2Eff : r1Eff;
     const ll = rowNum === 2 ? r2Line : r1Line;
+    const stairOffset = labelSteps.get(i) * textH;
     const [rpx, rpy] = pinPos(i);
     const col = pins[i].color;
     const name = escapeHtml(pins[i].name);
@@ -373,13 +383,13 @@ export function renderConnectorSVG(connector, connType) {
 
     let tx, ty, ta, tb;
     if (eff === "bottom") {
-      tx = rpx; ty = bodyBot + ll + textH - 2; ta = "middle"; tb = "auto";
+      tx = rpx; ty = bodyBot + ll + stairOffset + textH - 2; ta = "middle"; tb = "auto";
     } else if (eff === "top") {
-      tx = rpx; ty = bodyTop - ll - 3; ta = "middle"; tb = "auto";
+      tx = rpx; ty = bodyTop - ll - stairOffset - 3; ta = "middle"; tb = "auto";
     } else if (eff === "right") {
-      tx = bodyRgt + ll + 3; ty = rpy; ta = "start"; tb = "central";
+      tx = bodyRgt + ll + stairOffset + 3; ty = rpy; ta = "start"; tb = "central";
     } else {
-      tx = bodyLft - ll - 3; ty = rpy; ta = "end"; tb = "central";
+      tx = bodyLft - ll - stairOffset - 3; ty = rpy; ta = "end"; tb = "central";
     }
 
     parts.push(

--- a/pinout_design/js/svg-renderer.js
+++ b/pinout_design/js/svg-renderer.js
@@ -231,15 +231,15 @@ export function renderConnectorSVG(connector, connType) {
   const textH = fontSize + 3;
   const maxTextW = maxName * fontSize * charW + 4;
 
-  // Give every label on a side its own level. Dense connectors previously put
-  // all labels on one baseline and shrank the type until it fitted between the
-  // pins, which made it easy to associate a label with the wrong pin.
+  // Give top/bottom labels their own levels because they would otherwise share
+  // one horizontal baseline. Left/right labels already form a vertical list,
+  // so their leader lengths stay aligned.
   const sideCounts = Object.fromEntries(sides.map((side) => [side, 0]));
   const labelSteps = new Map();
   for (let i = 0; i < n; i++) {
     const [, rowNum] = pinMap.get(i);
     const eff = rowNum === 2 ? r2Eff : r1Eff;
-    labelSteps.set(i, sideCounts[eff]);
+    labelSteps.set(i, (eff === "bottom" || eff === "top") ? sideCounts[eff] : 0);
     sideCounts[eff] += 1;
   }
 

--- a/pinout_gen/pinout_gen/renderer.py
+++ b/pinout_gen/pinout_gen/renderer.py
@@ -253,15 +253,15 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
     text_h = font_sz + 3
     max_text_w = max_name * font_sz * char_w + 4
 
-    # Give every label on a side its own level.  Dense connectors previously put
-    # all labels on one baseline and shrank the type until it fitted between the
-    # pins, which made it easy to associate a label with the wrong pin.
+    # Give top/bottom labels their own levels because they would otherwise share
+    # one horizontal baseline. Left/right labels already form a vertical list,
+    # so their leader lengths stay aligned.
     side_counts = {s: 0 for s in sides}
     label_steps: dict[int, int] = {}
     for i in range(n):
         row_num = pin_map[i][1]
         eff = r2_eff if row_num == 2 else r1_eff
-        label_steps[i] = side_counts[eff]
+        label_steps[i] = side_counts[eff] if eff in ("bottom", "top") else 0
         side_counts[eff] += 1
 
     pad = {s: margin for s in sides}

--- a/pinout_gen/pinout_gen/renderer.py
+++ b/pinout_gen/pinout_gen/renderer.py
@@ -250,20 +250,27 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
     max_name = max((len(p.name) for p in pins), default=3)
     char_w = 0.6
     font_sz = 6.0
-    if n_per_row > 1 and max_name > 0:
-        font_sz = min(font_sz, geo.pin_pitch * 0.9 / (max_name * char_w))
-    font_sz = round(max(3.5, font_sz), 1)
     text_h = font_sz + 3
     max_text_w = max_name * font_sz * char_w + 4
 
-    eff_sides = {r1_eff}
-    if r2_global:
-        eff_sides.add(r2_eff)
-    max_line = max(r1_line, r2_line)
+    # Give every label on a side its own level.  Dense connectors previously put
+    # all labels on one baseline and shrank the type until it fitted between the
+    # pins, which made it easy to associate a label with the wrong pin.
+    side_counts = {s: 0 for s in sides}
+    label_steps: dict[int, int] = {}
+    for i in range(n):
+        row_num = pin_map[i][1]
+        eff = r2_eff if row_num == 2 else r1_eff
+        label_steps[i] = side_counts[eff]
+        side_counts[eff] += 1
 
     pad = {s: margin for s in sides}
-    for s in eff_sides:
-        pad[s] = max_line + (text_h if s in ("bottom", "top") else max_text_w)
+    for i in range(n):
+        row_num = pin_map[i][1]
+        eff = r2_eff if row_num == 2 else r1_eff
+        ll = r2_line if row_num == 2 else r1_line
+        label_extent = text_h if eff in ("bottom", "top") else max_text_w
+        pad[eff] = max(pad[eff], ll + label_steps[i] * text_h + label_extent)
 
     svg_w = pad["left"] + rot_w + pad["right"]
     svg_h = pad["top"] + rot_h + pad["bottom"]
@@ -290,12 +297,13 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
         row_num = pin_map[i][1]
         eff = r2_eff if row_num == 2 else r1_eff
         ll = r2_line if row_num == 2 else r1_line
+        stair_offset = label_steps[i] * text_h
         rpx, rpy = _pin_pos(i)
         col = pins[i].color
-        if eff == "bottom":   lx2, ly2 = rpx, body_bot + ll
-        elif eff == "top":    lx2, ly2 = rpx, body_top - ll
-        elif eff == "right":  lx2, ly2 = body_rgt + ll, rpy
-        else:                 lx2, ly2 = body_lft - ll, rpy
+        if eff == "bottom":   lx2, ly2 = rpx, body_bot + ll + stair_offset
+        elif eff == "top":    lx2, ly2 = rpx, body_top - ll - stair_offset
+        elif eff == "right":  lx2, ly2 = body_rgt + ll + stair_offset, rpy
+        else:                 lx2, ly2 = body_lft - ll - stair_offset, rpy
         parts.append(
             f'<line x1="{rpx:.1f}" y1="{rpy:.1f}" '
             f'x2="{lx2:.1f}" y2="{ly2:.1f}" '
@@ -362,6 +370,7 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
         row_num = pin_map[i][1]
         eff = r2_eff if row_num == 2 else r1_eff
         ll = r2_line if row_num == 2 else r1_line
+        stair_offset = label_steps[i] * text_h
         rpx, rpy = _pin_pos(i)
         col = pins[i].color
         name = html.escape(pins[i].name)
@@ -372,15 +381,14 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
             f'fill="{col}" stroke="var(--conn-stroke,#555)" stroke-width="0.9"/>'
         )
 
-        hs = body_stroke_w / 2
         if eff == "bottom":
-            tx, ty, ta, tb = rpx, body_bot + ll + text_h - 2, "middle", "auto"
+            tx, ty, ta, tb = rpx, body_bot + ll + stair_offset + text_h - 2, "middle", "auto"
         elif eff == "top":
-            tx, ty, ta, tb = rpx, body_top - ll - 3, "middle", "auto"
+            tx, ty, ta, tb = rpx, body_top - ll - stair_offset - 3, "middle", "auto"
         elif eff == "right":
-            tx, ty, ta, tb = body_rgt + ll + 3, rpy, "start", "central"
+            tx, ty, ta, tb = body_rgt + ll + stair_offset + 3, rpy, "start", "central"
         else:
-            tx, ty, ta, tb = body_lft - ll - 3, rpy, "end", "central"
+            tx, ty, ta, tb = body_lft - ll - stair_offset - 3, rpy, "end", "central"
 
         parts.append(
             f'<text x="{tx:.1f}" y="{ty:.1f}" font-size="{font_sz}" font-weight="500" '


### PR DESCRIPTION
**Summary**
place top/bottom pin labels on separate stepped levels
extend their leader lines to match each label level
keep left/right pin labels vertically aligned because they are already separated
expand the SVG padding so staggered labels are not clipped
keep the Python generator and browser designer renderers in sync

**Why**
Dense connectors previously placed labels on one shared baseline and reduced the font size to fit the available pin pitch. This made adjacent labels difficult to distinguish and increased the risk of associating a definition with the wrong pin.

The staircase layout preserves a readable label size and gives horizontally arranged pins visually distinct leaders. Connectors whose labels already form a vertical list keep equal leader lengths.

**Validation**
python -m compileall -q pinout_gen/pinout_gen
node --check pinout_design/js/svg-renderer.js
generated pinout_gen/example.toml successfully
checked that top/bottom orientations stair-step and left/right orientations remain aligned
checked a two-row connector
visually inspected the generated HTML
