### PR TITLE
Adds configurable rendering options for horizontal connectors

### DIFF
--- a/pinout_design/js/board-model.js
+++ b/pinout_design/js/board-model.js
@@ -65,6 +65,7 @@ export class Connector {
     this.y2 = data.y2 ?? 0;
     this.orientation = data.orientation ?? 0;
     this.description = data.description ?? "";
+    this.label_style = data.label_style ?? "staggered";
   }
 }
 

--- a/pinout_design/js/connector-panel.js
+++ b/pinout_design/js/connector-panel.js
@@ -81,6 +81,10 @@ export class ConnectorPanel {
       .map(d => `<option value="${d}" ${d === conn.orientation ? "selected" : ""}>${d}°</option>`)
       .join("");
 
+    const labelStyleOptions = ["staggered", "staircase", "flat"]
+      .map(s => `<option value="${s}" ${s === (conn.label_style || "staggered") ? "selected" : ""}>${s[0].toUpperCase() + s.slice(1)}</option>`)
+      .join("");
+
     this.container.innerHTML = `
       <div class="conn-form">
         <div class="conn-form-row">
@@ -96,6 +100,10 @@ export class ConnectorPanel {
           <select id="conn-type">${typeOptions}</select>
           <label style="width:auto">Orient.</label>
           <select id="conn-orient" style="width:70px;flex:none">${orientOptions}</select>
+        </div>
+        <div class="conn-form-row">
+          <label>Labels</label>
+          <select id="conn-label-style">${labelStyleOptions}</select>
         </div>
         <div class="conn-form-row">
           <label>Desc.</label>
@@ -248,6 +256,7 @@ export class ConnectorPanel {
     onFieldChange("#conn-name", "name");
     onFieldChange("#conn-type", "type");
     onFieldChange("#conn-orient", "orientation", v => parseInt(v));
+    onFieldChange("#conn-label-style", "label_style");
     onFieldChange("#conn-desc", "description");
 
     this.container.querySelectorAll(".pin-name-input").forEach(el => {

--- a/pinout_design/js/editor-panel.js
+++ b/pinout_design/js/editor-panel.js
@@ -216,6 +216,7 @@ export class EditorPanel {
       id: c.id, name: c.name, type: c.type,
       x1: c.x1, y1: c.y1, x2: c.x2, y2: c.y2,
       orientation: c.orientation, description: c.description,
+      label_style: c.label_style,
       pins: c.pins.map(p => ({ name: p.name, color: p.color, row: p.row })),
     }));
     const text = serializeBoardToml(
@@ -242,6 +243,7 @@ export class EditorPanel {
       id: conn.id, name: conn.name, type: conn.type,
       x1: conn.x1, y1: conn.y1, x2: conn.x2, y2: conn.y2,
       orientation: conn.orientation, description: conn.description,
+      label_style: conn.label_style,
       pins: conn.pins.map(p => ({ name: p.name, color: p.color, row: p.row })),
     };
 

--- a/pinout_design/js/svg-renderer.js
+++ b/pinout_design/js/svg-renderer.js
@@ -231,15 +231,20 @@ export function renderConnectorSVG(connector, connType) {
   const textH = fontSize + 3;
   const maxTextW = maxName * fontSize * charW + 4;
 
-  // Give top/bottom labels their own levels because they would otherwise share
-  // one horizontal baseline. Left/right labels already form a vertical list,
-  // so their leader lengths stay aligned.
   const sideCounts = Object.fromEntries(sides.map((side) => [side, 0]));
   const labelSteps = new Map();
+  const labelStyle = connector.label_style || "staggered";
   for (let i = 0; i < n; i++) {
     const [, rowNum] = pinMap.get(i);
     const eff = rowNum === 2 ? r2Eff : r1Eff;
-    labelSteps.set(i, (eff === "bottom" || eff === "top") ? sideCounts[eff] : 0);
+    const isHoriz = eff === "bottom" || eff === "top";
+    if (!isHoriz || labelStyle === "flat") {
+      labelSteps.set(i, 0);
+    } else if (labelStyle === "staggered") {
+      labelSteps.set(i, sideCounts[eff] % 2);
+    } else {
+      labelSteps.set(i, sideCounts[eff]);
+    }
     sideCounts[eff] += 1;
   }
 

--- a/pinout_design/js/toml-io.js
+++ b/pinout_design/js/toml-io.js
@@ -135,6 +135,7 @@ export function parseBoardToml(text) {
     y2: c.y2 || 0,
     orientation: c.orientation || 0,
     description: c.description || "",
+    label_style: c.label_style || "staggered",
     pins: (c.pin || []).map(p => ({
       name: p.name || "",
       color: p.color || "#888888",
@@ -207,6 +208,7 @@ export function serializeConnectorBlock(conn) {
   lines.push(`y2 = ${conn.y2}`);
   if (conn.orientation) lines.push(`orientation = ${conn.orientation}`);
   if (conn.description) lines.push(`description = ${quoteStr(conn.description)}`);
+  if (conn.label_style && conn.label_style !== "staggered") lines.push(`label_style = ${quoteStr(conn.label_style)}`);
 
   for (const pin of conn.pins) {
     lines.push("");

--- a/pinout_gen/pinout_gen/config.py
+++ b/pinout_gen/pinout_gen/config.py
@@ -73,6 +73,7 @@ class Connector:
     y2: int = 0
     orientation: int = 0
     description: str = ""
+    label_style: str = "staggered"
 
 
 @dataclass
@@ -110,6 +111,7 @@ def load_board(path: Path) -> Board:
             x1=c["x1"], y1=c["y1"], x2=c["x2"], y2=c["y2"],
             orientation=c.get("orientation", 0),
             description=c.get("description", ""),
+            label_style=c.get("label_style", "staggered"),
         ))
     return board
 

--- a/pinout_gen/pinout_gen/renderer.py
+++ b/pinout_gen/pinout_gen/renderer.py
@@ -253,15 +253,18 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
     text_h = font_sz + 3
     max_text_w = max_name * font_sz * char_w + 4
 
-    # Give top/bottom labels their own levels because they would otherwise share
-    # one horizontal baseline. Left/right labels already form a vertical list,
-    # so their leader lengths stay aligned.
     side_counts = {s: 0 for s in sides}
     label_steps: dict[int, int] = {}
+    label_style = connector.label_style
     for i in range(n):
         row_num = pin_map[i][1]
         eff = r2_eff if row_num == 2 else r1_eff
-        label_steps[i] = side_counts[eff] if eff in ("bottom", "top") else 0
+        if eff not in ("bottom", "top") or label_style == "flat":
+            label_steps[i] = 0
+        elif label_style == "staggered":
+            label_steps[i] = side_counts[eff] % 2
+        else:
+            label_steps[i] = side_counts[eff]
         side_counts[eff] += 1
 
     pad = {s: margin for s in sides}


### PR DESCRIPTION
This PR adds a configuration option per connector to make it possible to pick how a horizontal connector is rendered. Options are:
- All pin text on the same line
- Absak's staircased pin names (https://github.com/xbst/PinConnect/pull/9)
- Staggered pin names on 2 lines