### PR TITLE
Connector Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ The project works and generates great looking pinouts already. Below are changes
 
 - Add female Sherlock connectors
 - Add slide switch as a "connector" for highlighting its positions
-- Add option to staircase pin names when pinout lines go to top/bottom to avoid overlaps to `pinout-gen` (there already is a auto-scale feature implemented for this, but this will work better for long pin names)
 - Add theming to `pinout-gen` 
 - Update font of `pinout-design` to match the default `pinout-gen` theme (switch to Roboto)
 - Improve how `pinout-design` handles undo/redo for position adjustments (add them as a state)

--- a/docs/pinout-gen/board-toml.md
+++ b/docs/pinout-gen/board-toml.md
@@ -62,9 +62,32 @@ One entry per connector on the board.
 | `type` | yes | — | Connector type name, matched to `<type>.toml` in `connector_dir` (e.g. `MX-F-2R`). See [connector types](connector-types.md). |
 | `x1`, `y1`, `x2`, `y2` | yes | — | Bounding box of the connector on the image, in pixels. `(x1, y1)` and `(x2, y2)` are opposite corners. |
 | `orientation` | no | `0` | Rotation of the connector body in degrees: `0`, `90`, `180`, or `270`. |
+| `label_style` | no | `"staggered"` | How pin labels are arranged on horizontal connectors: `"staggered"`, `"staircase"`, or `"flat"`. See below. |
 | `description` | no | `""` | Longer text shown for the connector (e.g. a tooltip / detail line). |
 
 The bounding box places and sizes the connector graphic over the image; `orientation` rotates it so the rendered connector matches what's on the board. The designer sets all of these for you when you drag a box and pick an orientation.
+
+### `label_style`
+
+Controls how pin labels are spaced on horizontal (top/bottom) pinout sides. Has no effect on vertical (left/right) sides, where labels naturally stack without overlapping.
+
+| Value | Behaviour |
+|-------|-----------|
+| `"staggered"` | Odd and even pin labels alternate between two levels. Compact while still avoiding overlap. **(default)** |
+| `"staircase"` | Each pin label gets its own level, stepping further from the connector body. Clearest separation, but tall with many pins. |
+| `"flat"` | All labels sit at the same level. Most compact, but labels may overlap on dense connectors. |
+
+```toml
+[[connector]]
+id = "J1"
+name = "Sensor Header"
+type = "HDR-254"
+x1 = 100
+y1 = 200
+x2 = 250
+y2 = 220
+label_style = "flat"
+```
 
 ## `[[connector.pin]]`
 

--- a/docs/pinout-gen/connector-types.md
+++ b/docs/pinout-gen/connector-types.md
@@ -10,12 +10,13 @@ Type definitions live in `pinout_gen/pinout_gen/connectors/`, one `.toml` file p
 |------|-------|-------|
 | `XH-F` | latch | JST XH female, single row |
 | `PH-F` | latch | JST PH female, single row |
-| `HDR-127` | header-female | 1.27 mm female pin header |
-| `HDR-200` | header-female | 2.00 mm female pin header |
-| `HDR-254` | header-female | 2.54 mm female pin header |
+| `HDR-127` | header-male | 1.27 mm male pin header |
+| `HDR-200` | header-male | 2.00 mm male pin header |
+| `HDR-254` | header-male | 2.54 mm male pin header |
 | `ST-254` | screw-terminal | 2.54 mm pitch screw terminal |
 | `ST-508` | screw-terminal | 5.08 mm pitch screw terminal |
-| `ST-OA` | open-air | 5.08 mm open-air screw terminal strip |
+| `ST-BR-508` | barrier | 5.08 mm barrier screw terminal strip |
+| `ST-BR-950` | barrier | 9.5 mm barrier screw terminal strip |
 | `MX-F-1R` | grid | Micro-Fit female, single row |
 | `MX-F-2R` | grid | Micro-Fit female, two rows |
 | `USB-C` | box | Simple rectangular body |
@@ -55,9 +56,9 @@ cavity_size = 10.5
   - `latch` — a latching housing (JST XH / PH look).
   - `grid` — a gridded housing with cavities (Micro-Fit look); uses `cavity_size`.
   - `xt30` — the XT30 power-connector body.
-  - `header-female` — a pitch-scaled female pin-header housing with square cavities and keyed joints.
-  - `screw-terminal` — a screw-terminal housing with circular screw heads and side wire-entry slots.
-  - `open-air` — an exposed screw-terminal strip with individual metal cages and cross-drive screws.
+  - `header-male` — a pitch-scaled male pin-header housing with square cavities and keyed joints.
+  - `screw-terminal` — a screw-terminal with circular screw heads and side wire-entry slots.
+  - `barrier` — a barrier screw-terminal with individual metal cages and cross-drive screws.
 
 ### `[geometry]`
 

--- a/pinout_design/connectors/HDR-127.json
+++ b/pinout_design/connectors/HDR-127.json
@@ -1,16 +1,16 @@
 {
   "name": "1.27mm Header",
-  "style": "box",
+  "style": "header-male",
   "geometry": {
     "pin_pitch": 5.0,
-    "padding_left": 3.5,
-    "padding_right": 3.5,
-    "height": 6.0,
-    "wall": 1.0,
-    "pin_cy": 3.0,
-    "pin_radius": 1.0,
+    "padding_left": 2.5,
+    "padding_right": 2.5,
+    "height": 5.0,
+    "wall": 0.8,
+    "pin_cy": 2.5,
+    "pin_radius": 0.65,
     "pinout_side": "bottom",
-    "line_length": 8.0,
+    "line_length": 6.0,
     "rows": 1,
     "row2_pin_cy": 0.0,
     "row2_pinout_side": "top",
@@ -18,6 +18,6 @@
     "row2_padding_left": -1.0,
     "row2_pin_pitch_y": 0.0,
     "row2_pin_radius": -1.0,
-    "cavity_size": 0.0
+    "cavity_size": 1.25
   }
 }

--- a/pinout_design/connectors/HDR-200.json
+++ b/pinout_design/connectors/HDR-200.json
@@ -1,14 +1,14 @@
 {
   "name": "2.00mm Header",
-  "style": "box",
+  "style": "header-male",
   "geometry": {
     "pin_pitch": 8.0,
-    "padding_left": 5.0,
-    "padding_right": 5.0,
+    "padding_left": 4.0,
+    "padding_right": 4.0,
     "height": 8.0,
-    "wall": 1.3,
+    "wall": 1.2,
     "pin_cy": 4.0,
-    "pin_radius": 1.6,
+    "pin_radius": 1.04,
     "pinout_side": "bottom",
     "line_length": 10.0,
     "rows": 1,
@@ -18,6 +18,6 @@
     "row2_padding_left": -1.0,
     "row2_pin_pitch_y": 0.0,
     "row2_pin_radius": -1.0,
-    "cavity_size": 0.0
+    "cavity_size": 2.0
   }
 }

--- a/pinout_design/connectors/HDR-254.json
+++ b/pinout_design/connectors/HDR-254.json
@@ -1,14 +1,14 @@
 {
   "name": "2.54mm Header",
-  "style": "box",
+  "style": "header-male",
   "geometry": {
     "pin_pitch": 10.0,
-    "padding_left": 6.0,
-    "padding_right": 6.0,
+    "padding_left": 5.0,
+    "padding_right": 5.0,
     "height": 10.0,
     "wall": 1.5,
     "pin_cy": 5.0,
-    "pin_radius": 2.0,
+    "pin_radius": 1.3,
     "pinout_side": "bottom",
     "line_length": 12.0,
     "rows": 1,
@@ -18,6 +18,6 @@
     "row2_padding_left": -1.0,
     "row2_pin_pitch_y": 0.0,
     "row2_pin_radius": -1.0,
-    "cavity_size": 0.0
+    "cavity_size": 2.5
   }
 }

--- a/pinout_design/connectors/ST-254.json
+++ b/pinout_design/connectors/ST-254.json
@@ -1,0 +1,23 @@
+{
+  "name": "2.54mm Screw Terminal",
+  "style": "screw-terminal",
+  "geometry": {
+    "pin_pitch": 10.0,
+    "padding_left": 5.9,
+    "padding_right": 5.9,
+    "height": 24.4,
+    "wall": 1.2,
+    "pin_cy": 12.2,
+    "pin_radius": 0.9,
+    "pinout_side": "bottom",
+    "line_length": 12.0,
+    "rows": 1,
+    "row2_pin_cy": 0.0,
+    "row2_pinout_side": "top",
+    "row2_line_length": 20.0,
+    "row2_padding_left": -1.0,
+    "row2_pin_pitch_y": 0.0,
+    "row2_pin_radius": -1.0,
+    "cavity_size": 8.2
+  }
+}

--- a/pinout_design/connectors/ST-508.json
+++ b/pinout_design/connectors/ST-508.json
@@ -1,0 +1,24 @@
+{
+  "name": "5.08mm Screw Terminal",
+  "style": "screw-terminal",
+  "geometry": {
+    "pin_pitch": 20.0,
+    "padding_left": 12.3,
+    "padding_right": 12.3,
+    "height": 46.9,
+    "wall": 2.4,
+    "pin_cy": 23.5,
+    "pin_radius": 1.8,
+    "pinout_side": "bottom",
+    "line_length": 20.0,
+    "rows": 1,
+    "row2_pin_cy": 0.0,
+    "row2_pinout_side": "top",
+    "row2_line_length": 20.0,
+    "row2_padding_left": -1.0,
+    "row2_pin_pitch_y": 0.0,
+    "row2_pin_radius": -1.0,
+    "cavity_size": 16.4,
+    "mating_pin_scale": 2.3
+  }
+}

--- a/pinout_design/connectors/ST-BR-508.json
+++ b/pinout_design/connectors/ST-BR-508.json
@@ -1,0 +1,23 @@
+{
+  "name": "5.08mm Barrier Screw Terminal",
+  "style": "barrier",
+  "geometry": {
+    "pin_pitch": 20.0,
+    "padding_left": 12.0,
+    "padding_right": 12.0,
+    "height": 31.0,
+    "wall": 1.5,
+    "pin_cy": 15.5,
+    "pin_radius": 1.8,
+    "pinout_side": "bottom",
+    "line_length": 20.0,
+    "rows": 1,
+    "row2_pin_cy": 0.0,
+    "row2_pinout_side": "top",
+    "row2_line_length": 20.0,
+    "row2_padding_left": -1.0,
+    "row2_pin_pitch_y": 0.0,
+    "row2_pin_radius": -1.0,
+    "cavity_size": 16.0
+  }
+}

--- a/pinout_design/connectors/ST-BR-950.json
+++ b/pinout_design/connectors/ST-BR-950.json
@@ -1,0 +1,23 @@
+{
+  "name": "9.5mm Barrier Screw Terminal",
+  "style": "barrier",
+  "geometry": {
+    "pin_pitch": 37.4,
+    "padding_left": 22.4,
+    "padding_right": 22.4,
+    "height": 58.0,
+    "wall": 2.8,
+    "pin_cy": 29.0,
+    "pin_radius": 3.4,
+    "pinout_side": "bottom",
+    "line_length": 25.0,
+    "rows": 1,
+    "row2_pin_cy": 0.0,
+    "row2_pinout_side": "top",
+    "row2_line_length": 20.0,
+    "row2_padding_left": -1.0,
+    "row2_pin_pitch_y": 0.0,
+    "row2_pin_radius": -1.0,
+    "cavity_size": 29.9
+  }
+}

--- a/pinout_design/connectors/index.json
+++ b/pinout_design/connectors/index.json
@@ -1,12 +1,16 @@
 [
+  "button",
   "HDR-127",
   "HDR-200",
   "HDR-254",
   "MX-F-1R",
   "MX-F-2R",
   "PH-F",
+  "ST-254",
+  "ST-508",
+  "ST-BR-508",
+  "ST-BR-950",
   "USB-C",
   "XH-F",
-  "XT30-2+2",
-  "button"
+  "XT30-2+2"
 ]

--- a/pinout_design/js/svg-renderer.js
+++ b/pinout_design/js/svg-renderer.js
@@ -92,7 +92,7 @@ function bodyPathButton(geo, nPerRow) {
   );
 }
 
-function bodyPathHeaderFemale(geo, nPerRow) {
+function bodyPathHeaderMale(geo, nPerRow) {
   const W = geo.connectorWidth(nPerRow), H = geo.height;
   const chamfer = Math.min(geo.pin_pitch * 0.10, W / 4, H / 4);
   const notch = Math.min(geo.pin_pitch * 0.20, H / 3);
@@ -113,7 +113,7 @@ function bodyPathHeaderFemale(geo, nPerRow) {
   return d + " Z";
 }
 
-function headerFemaleCavities(geo, nPerRow) {
+function headerMaleCavities(geo, nPerRow) {
   const cavity = geo.cavity_size > 0 ? geo.cavity_size : Math.min(geo.pin_pitch * 0.25, geo.height * 0.25);
   const half = cavity / 2;
   const fill = 'fill="var(--conn-cavity,#d0d0c8)"';
@@ -200,12 +200,12 @@ function screwTerminalCavities(geo, nPerRow) {
   return parts.join("\n");
 }
 
-function bodyPathOpenAir(geo, nPerRow) {
+function bodyPathBarrier(geo, nPerRow) {
   const W = geo.connectorWidth(nPerRow), H = geo.height;
   return `M 0,0 L ${f1(W)},0 L ${f1(W)},${f1(H)} L 0,${f1(H)} Z`;
 }
 
-function openAirDetails(geo, nPerRow) {
+function barrierDetails(geo, nPerRow) {
   const W = geo.connectorWidth(nPerRow), H = geo.height, p = geo.pin_pitch;
   const screwR = Math.min(geo.cavity_size > 0 ? geo.cavity_size / 2 : p * 0.40, p * 0.42);
   const frameFill = 'fill="var(--conn-body,#e8e8e0)"';
@@ -475,9 +475,9 @@ export function renderConnectorSVG(connector, connType) {
   if (style === "latch")      pathD = bodyPathLatch(geo, nPerRow);
   else if (style === "grid")  pathD = bodyPathGrid(geo, nPerRow);
   else if (style === "xt30")  pathD = bodyPathXt30(geo, nPerRow);
-  else if (style === "header-female") pathD = bodyPathHeaderFemale(geo, nPerRow);
+  else if (style === "header-male") pathD = bodyPathHeaderMale(geo, nPerRow);
   else if (style === "screw-terminal") pathD = bodyPathScrewTerminal(geo, nPerRow);
-  else if (style === "open-air") pathD = bodyPathOpenAir(geo, nPerRow);
+  else if (style === "barrier") pathD = bodyPathBarrier(geo, nPerRow);
   else if (style === "button") pathD = bodyPathButton(geo, nPerRow);
   else                        pathD = bodyPathBox(geo, nPerRow);
 
@@ -491,12 +491,12 @@ export function renderConnectorSVG(connector, connType) {
   const w = geo.wall;
   if (style === "xt30") {
     parts.push(xt30Cavities(geo, nPerRow));
-  } else if (style === "header-female") {
-    parts.push(headerFemaleCavities(geo, nPerRow));
+  } else if (style === "header-male") {
+    parts.push(headerMaleCavities(geo, nPerRow));
   } else if (style === "screw-terminal") {
     parts.push(screwTerminalCavities(geo, nPerRow));
-  } else if (style === "open-air") {
-    parts.push(openAirDetails(geo, nPerRow));
+  } else if (style === "barrier") {
+    parts.push(barrierDetails(geo, nPerRow));
   } else if (style === "button") {
     parts.push(buttonCavities(geo, nPerRow));
   } else if (style === "grid" && geo.cavity_size > 0) {

--- a/pinout_gen/pinout_gen/config.py
+++ b/pinout_gen/pinout_gen/config.py
@@ -49,7 +49,7 @@ class ConnectorGeometry:
 @dataclass
 class ConnectorType:
     name: str
-    style: str  # "latch" (XH/PH) or "box" (simple rectangle)
+    style: str
     geometry: ConnectorGeometry
 
 

--- a/pinout_gen/pinout_gen/connectors/HDR-127.toml
+++ b/pinout_gen/pinout_gen/connectors/HDR-127.toml
@@ -1,6 +1,6 @@
 [connector]
 name = "1.27mm Header"
-style = "header-female"
+style = "header-male"
 
 [geometry]
 pin_pitch = 5.0

--- a/pinout_gen/pinout_gen/connectors/HDR-200.toml
+++ b/pinout_gen/pinout_gen/connectors/HDR-200.toml
@@ -1,6 +1,6 @@
 [connector]
 name = "2.00mm Header"
-style = "header-female"
+style = "header-male"
 
 [geometry]
 pin_pitch = 8.0

--- a/pinout_gen/pinout_gen/connectors/HDR-254.toml
+++ b/pinout_gen/pinout_gen/connectors/HDR-254.toml
@@ -1,6 +1,6 @@
 [connector]
 name = "2.54mm Header"
-style = "header-female"
+style = "header-male"
 
 [geometry]
 pin_pitch = 10.0

--- a/pinout_gen/pinout_gen/connectors/ST-BR-950.toml
+++ b/pinout_gen/pinout_gen/connectors/ST-BR-950.toml
@@ -1,0 +1,15 @@
+[connector]
+name = "9.5mm Barrier Screw Terminal"
+style = "barrier"
+
+[geometry]
+pin_pitch = 37.4
+padding_left = 22.4
+padding_right = 22.4
+height = 58.0
+wall = 2.8
+pin_cy = 29.0
+pin_radius = 3.4
+pinout_side = "bottom"
+line_length = 25.0
+cavity_size = 29.9

--- a/pinout_gen/pinout_gen/renderer.py
+++ b/pinout_gen/pinout_gen/renderer.py
@@ -94,8 +94,8 @@ def _body_path_button(geo: ConnectorGeometry, n_per_row: int) -> str:
     )
 
 
-def _body_path_header_female(geo: ConnectorGeometry, n_per_row: int) -> str:
-    """Female header housing with pitch-scaled chamfers and keyed joints."""
+def _body_path_header_male(geo: ConnectorGeometry, n_per_row: int) -> str:
+    """Male header housing with pitch-scaled chamfers and keyed joints."""
     W, H = geo.connector_width(n_per_row), geo.height
     chamfer = min(geo.pin_pitch * 0.10, W / 4, H / 4)
     notch = min(geo.pin_pitch * 0.20, H / 3)
@@ -115,7 +115,7 @@ def _body_path_header_female(geo: ConnectorGeometry, n_per_row: int) -> str:
     return d + " Z"
 
 
-def _header_female_cavities(geo: ConnectorGeometry, n_per_row: int) -> str:
+def _header_male_cavities(geo: ConnectorGeometry, n_per_row: int) -> str:
     cavity = geo.cavity_size if geo.cavity_size > 0 else min(geo.pin_pitch * 0.25, geo.height * 0.25)
     half = cavity / 2
     fill = 'fill="var(--conn-cavity,#d0d0c8)"'
@@ -207,14 +207,14 @@ def _screw_terminal_cavities(geo: ConnectorGeometry, n_per_row: int) -> str:
     return '\n'.join(parts)
 
 
-def _body_path_open_air(geo: ConnectorGeometry, n_per_row: int) -> str:
-    """Rectangular outer frame for an open-air screw terminal strip."""
+def _body_path_barrier(geo: ConnectorGeometry, n_per_row: int) -> str:
+    """Rectangular outer frame for a barrier screw terminal strip."""
     W, H = geo.connector_width(n_per_row), geo.height
     return f"M 0,0 L {W:.1f},0 L {W:.1f},{H:.1f} L 0,{H:.1f} Z"
 
 
-def _open_air_details(geo: ConnectorGeometry, n_per_row: int) -> str:
-    """Open metal cages, frame rails, and cross-drive screw heads."""
+def _barrier_details(geo: ConnectorGeometry, n_per_row: int) -> str:
+    """Metal cages, frame rails, and cross-drive screw heads."""
     W, H, p = geo.connector_width(n_per_row), geo.height, geo.pin_pitch
     screw_r = min(geo.cavity_size / 2 if geo.cavity_size > 0 else p * 0.40, p * 0.42)
     frame_fill = 'fill="var(--conn-body,#e8e8e0)"'
@@ -484,12 +484,12 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
         path_d = _body_path_grid(geo, n_per_row)
     elif style == "xt30":
         path_d = _body_path_xt30(geo, n_per_row)
-    elif style == "header-female":
-        path_d = _body_path_header_female(geo, n_per_row)
+    elif style == "header-male":
+        path_d = _body_path_header_male(geo, n_per_row)
     elif style == "screw-terminal":
         path_d = _body_path_screw_terminal(geo, n_per_row)
-    elif style == "open-air":
-        path_d = _body_path_open_air(geo, n_per_row)
+    elif style == "barrier":
+        path_d = _body_path_barrier(geo, n_per_row)
     elif style == "button":
         path_d = _body_path_button(geo, n_per_row)
     else:
@@ -505,12 +505,12 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
     w = geo.wall
     if style == "xt30":
         parts.append(_xt30_cavities(geo, n_per_row))
-    elif style == "header-female":
-        parts.append(_header_female_cavities(geo, n_per_row))
+    elif style == "header-male":
+        parts.append(_header_male_cavities(geo, n_per_row))
     elif style == "screw-terminal":
         parts.append(_screw_terminal_cavities(geo, n_per_row))
-    elif style == "open-air":
-        parts.append(_open_air_details(geo, n_per_row))
+    elif style == "barrier":
+        parts.append(_barrier_details(geo, n_per_row))
     elif style == "button":
         parts.append(_button_cavities(geo, n_per_row))
     elif style == "grid" and geo.cavity_size > 0:


### PR DESCRIPTION
This PR:
- Documents label_style from previous PR
- Removes staircasing todo (implemented in previous PR)
- https://github.com/xbst/PinConnect/pull/10 had some connector naming issues this PR corrects:
  - "Open Air" screw terminal renamed to barrier screw terminal
  - "Female" headers renamed to male headers (standard pin headers are male)
- Adds 9.50mm barrier screw terminal