### PR TITLE
Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ The project works and generates great looking pinouts already. Below are changes
 - Add slide switch as a "connector" for highlighting its positions
 - Add theming to `pinout-gen` 
 - Update font of `pinout-design` to match the default `pinout-gen` theme (switch to Roboto)
-- Improve how `pinout-design` handles undo/redo for position adjustments (add them as a state)
 - Write a more detailed doc with screenshots for `pinout-design`
 - Add a screenshot of the output to this document
 

--- a/pinout_design/js/board-panel.js
+++ b/pinout_design/js/board-panel.js
@@ -302,9 +302,15 @@ export class BoardPanel {
     if ((drag.type === "move" || drag.type === "resize") && drag.moved) {
       const conn = this.state.getConnector(drag.id);
       if (conn) {
-        this.state.updateConnector(drag.id, {
-          x1: conn.x1, y1: conn.y1, x2: conn.x2, y2: conn.y2,
-        }, "visual");
+        const { x1, y1, x2, y2 } = conn;
+        if (x1 !== drag.origX1 || y1 !== drag.origY1 ||
+            x2 !== drag.origX2 || y2 !== drag.origY2) {
+          // The drag mutated the connector in place for live feedback; restore
+          // the pre-drag coordinates so updateConnector snapshots them for undo.
+          conn.x1 = drag.origX1; conn.y1 = drag.origY1;
+          conn.x2 = drag.origX2; conn.y2 = drag.origY2;
+          this.state.updateConnector(drag.id, { x1, y1, x2, y2 }, "visual");
+        }
       }
     }
   }

--- a/pinout_design/js/board-panel.js
+++ b/pinout_design/js/board-panel.js
@@ -103,6 +103,14 @@ export class BoardPanel {
     });
     this.state.on("connector-added", () => this._renderRects());
     this.state.on("connector-removed", () => this._renderRects());
+    this.state.on("connector-renamed", ({ oldId, newId }) => {
+      if (!this.svg) return;
+      const g = this.svg.querySelector(`g[data-id="${oldId}"]`);
+      if (!g) return;
+      g.setAttribute("data-id", newId);
+      const label = g.querySelector(".board-rect-label");
+      if (label) label.textContent = newId;
+    });
     this.state.on("selection-changed", ({ connectorId }) => this._highlightSelected(connectorId));
   }
 
@@ -369,7 +377,10 @@ export class BoardPanel {
       const id = dialog.querySelector("#new-conn-id").value.trim();
       const name = dialog.querySelector("#new-conn-name").value.trim();
       const type = dialog.querySelector("#new-conn-type").value;
-      if (!id) return;
+      if (!id || this.state.getConnector(id)) {
+        dialog.querySelector("#new-conn-id").style.borderColor = "var(--danger)";
+        return;
+      }
       close();
       this.state.addConnector(new Connector({
         id, name: name || id, type,

--- a/pinout_design/js/connector-panel.js
+++ b/pinout_design/js/connector-panel.js
@@ -244,8 +244,9 @@ export class ConnectorPanel {
         const val = transform(el.value);
         if (key === "id") {
           const oldId = this.state.selectedConnectorId;
-          this.state.updateConnector(oldId, { id: val }, "visual");
-          this.state.selectConnector(val);
+          if (!this.state.renameConnector(oldId, val.trim(), "visual")) {
+            this._render(); // invalid (empty/duplicate) — restore the current ID
+          }
         } else {
           this.state.updateConnector(cid, { [key]: val }, "visual");
         }

--- a/pinout_design/js/editor-panel.js
+++ b/pinout_design/js/editor-panel.js
@@ -136,6 +136,11 @@ export class EditorPanel {
       this._suppressSync = false;
     });
 
+    this.state.on("connector-renamed", ({ newId, origin }) => {
+      if (origin === "editor") return;
+      this._patchConnector(newId);
+    });
+
     this.state.on("pin-changed", ({ connectorId, origin }) => {
       if (origin === "editor") return;
       this._patchConnector(connectorId);

--- a/pinout_design/js/main.js
+++ b/pinout_design/js/main.js
@@ -73,19 +73,9 @@ function setupFileIO(editorPanel) {
       const img = new Image();
       img.onload = () => {
         if (!state.board) {
-          state.setBoard(new Board({
-            title: "Pinout",
-            image: file.name,
-            width: img.naturalWidth,
-            height: img.naturalHeight,
-          }), "init");
-          editorPanel._syncFromState();
-        } else {
-          state.board.image = file.name;
-          state.board.width = img.naturalWidth;
-          state.board.height = img.naturalHeight;
+          state.setBoard(new Board({ title: "Pinout" }), "init");
         }
-        state.setImage(reader.result, img.naturalWidth, img.naturalHeight);
+        state.setImage(reader.result, file.name, img.naturalWidth, img.naturalHeight);
       };
       img.src = reader.result;
     };

--- a/pinout_design/js/state.js
+++ b/pinout_design/js/state.js
@@ -107,13 +107,22 @@ export class BoardState {
     this._origin = null;
   }
 
-  setImage(dataUrl, width, height) {
+  setImage(dataUrl, imageName, width, height) {
     this.imageDataUrl = dataUrl;
     if (this.board) {
+      this.board.image = imageName;
       this.board.width = width;
       this.board.height = height;
+      this.dirty = true;
     }
     this.emit("image-changed", { dataUrl, width, height });
+    // Board fields changed too; emit board-changed so the editor TOML and
+    // panels sync immediately instead of on the next unrelated mutation.
+    if (this.board) {
+      this._origin = "image";
+      this.emit("board-changed", { board: this.board, origin: "image" });
+      this._origin = null;
+    }
   }
 
   selectConnector(id) {

--- a/pinout_design/js/state.js
+++ b/pinout_design/js/state.js
@@ -155,11 +155,32 @@ export class BoardState {
     this._origin = null;
   }
 
-  addConnector(data, origin = "visual") {
-    if (!this.board) return;
+  // ID changes must go through renameConnector, not updateConnector: the id is
+  // the key used by events, the canvas DOM, and the selection pointer.
+  renameConnector(oldId, newId, origin = "visual") {
+    const conn = this.getConnector(oldId);
+    if (!conn) return false;
+    if (newId === oldId) return true;
+    if (!newId || this.getConnector(newId)) return false;
     this._pushUndo();
     this._origin = origin;
+    conn.id = newId;
+    this.dirty = true;
+    this.emit("connector-renamed", { oldId, newId, connector: conn, origin });
+    if (this.selectedConnectorId === oldId) {
+      this.selectedConnectorId = newId;
+      this.emit("selection-changed", { connectorId: newId });
+    }
+    this._origin = null;
+    return true;
+  }
+
+  addConnector(data, origin = "visual") {
+    if (!this.board) return;
     const conn = data instanceof Connector ? data : new Connector(data);
+    if (!conn.id || this.getConnector(conn.id)) return null;
+    this._pushUndo();
+    this._origin = origin;
     this.board.connectors.push(conn);
     this.dirty = true;
     this.emit("connector-added", { connectorId: conn.id, connector: conn, origin });

--- a/pinout_design/js/state.js
+++ b/pinout_design/js/state.js
@@ -191,7 +191,9 @@ export class BoardState {
     this._origin = origin;
     conn.pins.push(pin instanceof Pin ? pin : new Pin(pin.name, pin.color, pin.row));
     this.dirty = true;
-    this.emit("pin-changed", { connectorId, pinIndex: conn.pins.length - 1, origin });
+    // pinIndex -1 marks a structural change (same as removePin), so listeners
+    // rebuild the pin list instead of treating this as an in-place row edit.
+    this.emit("pin-changed", { connectorId, pinIndex: -1, origin });
     this._origin = null;
   }
 

--- a/pinout_design/js/state.js
+++ b/pinout_design/js/state.js
@@ -48,6 +48,7 @@ export class BoardState {
         id: c.id, name: c.name, type: c.type,
         x1: c.x1, y1: c.y1, x2: c.x2, y2: c.y2,
         orientation: c.orientation, description: c.description,
+        label_style: c.label_style,
         pins: c.pins.map(p => ({ name: p.name, color: p.color, row: p.row })),
       })),
       selectedConnectorId: this.selectedConnectorId,

--- a/pinout_design/js/svg-renderer.js
+++ b/pinout_design/js/svg-renderer.js
@@ -416,6 +416,22 @@ export function renderConnectorSVG(connector, connType) {
     sideCounts[eff] += 1;
   }
 
+  // Rotated offset of a pin from the body centre; independent of padding,
+  // so it can size the padding itself and later place the pins.
+  function pinOffset(pinIdx) {
+    const [rowSlot, rowNum] = pinMap.get(pinIdx);
+    let px0, py0;
+    if (rowNum === 2 && geo.row2_pin_pitch_y > 0) {
+      const r2Pl = geo.row2_padding_left >= 0 ? geo.row2_padding_left : geo.padding_left;
+      px0 = r2Pl;
+      py0 = geo.row2_pin_cy + (rowSlot - (r2Global.length - 1) / 2) * geo.row2_pin_pitch_y;
+    } else {
+      px0 = pxs0[rowSlot];
+      py0 = rowNum !== 2 ? geo.pin_cy : geo.row2_pin_cy;
+    }
+    return rotateCW(px0 - cx0, py0 - cy0, ori);
+  }
+
   const pad = {};
   for (const s of sides) pad[s] = margin;
   for (let i = 0; i < n; i++) {
@@ -424,6 +440,14 @@ export function renderConnectorSVG(connector, connType) {
     const ll = rowNum === 2 ? r2Line : r1Line;
     const labelExtent = (eff === "bottom" || eff === "top") ? textH : maxTextW;
     pad[eff] = Math.max(pad[eff], ll + labelSteps.get(i) * textH + labelExtent);
+    if (eff === "bottom" || eff === "top") {
+      // Middle-anchored labels extend horizontally past the body on edge
+      // pins; widen the side paddings by the overhang so they aren't cropped.
+      const halfW = (pins[i].name.length * fontSize * charW) / 2 + 2;
+      const [rdx] = pinOffset(i);
+      pad["left"] = Math.max(pad["left"], margin + halfW - (rotW / 2 + rdx));
+      pad["right"] = Math.max(pad["right"], margin + halfW - (rotW / 2 - rdx));
+    }
   }
 
   const svgW = pad["left"] + rotW + pad["right"];
@@ -440,19 +464,7 @@ export function renderConnectorSVG(connector, connType) {
   const pxH = Math.round(svgH * SCALE);
 
   function pinPos(pinIdx) {
-    const [rowSlot, rowNum] = pinMap.get(pinIdx);
-    let px0, py0;
-    if (rowNum === 2 && geo.row2_pin_pitch_y > 0) {
-      const r2Pl = geo.row2_padding_left >= 0 ? geo.row2_padding_left : geo.padding_left;
-      px0 = r2Pl;
-      const nR2 = r2Global.length;
-      py0 = geo.row2_pin_cy + (rowSlot - (nR2 - 1) / 2) * geo.row2_pin_pitch_y;
-    } else {
-      px0 = pxs0[rowSlot];
-      py0 = rowNum !== 2 ? geo.pin_cy : geo.row2_pin_cy;
-    }
-    const dx = px0 - cx0, dy = py0 - cy0;
-    const [rdx, rdy] = rotateCW(dx, dy, ori);
+    const [rdx, rdy] = pinOffset(pinIdx);
     return [connCx + rdx, connCy + rdy];
   }
 

--- a/pinout_design/js/toml-io.js
+++ b/pinout_design/js/toml-io.js
@@ -66,10 +66,15 @@ export function parseToml(text) {
 }
 
 function stripComment(line) {
-  let inStr = false, quote = null;
+  let inStr = false, quote = null, escaped = false;
   for (let i = 0; i < line.length; i++) {
     const ch = line[i];
-    if (inStr) { if (ch === quote && line[i - 1] !== "\\") inStr = false; }
+    if (inStr) {
+      if (escaped) { escaped = false; continue; }
+      // Escapes only exist in basic (double-quoted) strings, not literal ones.
+      if (ch === "\\" && quote === '"') { escaped = true; continue; }
+      if (ch === quote) inStr = false;
+    }
     else if (ch === '"' || ch === "'") { inStr = true; quote = ch; }
     else if (ch === "#") return line.slice(0, i);
   }
@@ -79,11 +84,21 @@ function stripComment(line) {
 function parseTomlValue(val, lineNum) {
   // Quoted string (double)
   if (val.startsWith('"')) {
-    const end = val.indexOf('"', 1);
+    let end = -1;
+    for (let i = 1; i < val.length; i++) {
+      if (val[i] === "\\") { i++; continue; }
+      if (val[i] === '"') { end = i; break; }
+    }
     if (end === -1) throw new TomlParseError("Unterminated string", lineNum);
-    return val.slice(1, end)
-      .replace(/\\n/g, "\n").replace(/\\t/g, "\t")
-      .replace(/\\\\/g, "\\").replace(/\\"/g, '"');
+    // Single left-to-right pass so "\\n" is a backslash + n, not a newline.
+    return val.slice(1, end).replace(/\\(u[0-9A-Fa-f]{4}|.)/g, (m, esc) => {
+      if (esc === "n") return "\n";
+      if (esc === "t") return "\t";
+      if (esc === "r") return "\r";
+      if (esc === '"' || esc === "\\") return esc;
+      if (esc[0] === "u") return String.fromCharCode(parseInt(esc.slice(1), 16));
+      return m;
+    });
   }
   // Quoted string (single)
   if (val.startsWith("'")) {
@@ -194,7 +209,14 @@ export function buildSourceMap(text) {
 // --- Serialization ---
 
 function quoteStr(s) {
-  return '"' + s.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+  return '"' + s.replace(/[\\"\u0000-\u001f]/g, (ch) => {
+    if (ch === "\\") return "\\\\";
+    if (ch === '"') return '\\"';
+    if (ch === "\n") return "\\n";
+    if (ch === "\t") return "\\t";
+    if (ch === "\r") return "\\r";
+    return "\\u" + ch.charCodeAt(0).toString(16).padStart(4, "0").toUpperCase();
+  }) + '"';
 }
 
 export function serializeConnectorBlock(conn) {

--- a/pinout_gen/pinout_gen/connectors/ST-BR-508.toml
+++ b/pinout_gen/pinout_gen/connectors/ST-BR-508.toml
@@ -1,6 +1,6 @@
 [connector]
-name = "ST-OA (Open Air)"
-style = "open-air"
+name = "5.08mm Barrier Screw Terminal"
+style = "barrier"
 
 [geometry]
 pin_pitch = 20.0

--- a/pinout_gen/pinout_gen/renderer.py
+++ b/pinout_gen/pinout_gen/renderer.py
@@ -395,8 +395,10 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
     else:
         rot_w, rot_h = conn_h, conn_w
 
-    # ── Pin position helper ──
-    def _pin_pos(pin_idx: int) -> tuple[float, float]:
+    # ── Pin position helpers ──
+    def _pin_offset(pin_idx: int) -> tuple[float, float]:
+        """Rotated offset of a pin from the body centre; independent of
+        padding, so it can size the padding itself and later place pins."""
         row_slot, row_num = pin_map[pin_idx]
         if row_num == 2 and geo.row2_pin_pitch_y > 0:
             r2_pl = geo.row2_padding_left if geo.row2_padding_left >= 0 else geo.padding_left
@@ -406,8 +408,10 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
         else:
             px0 = pxs0[row_slot]
             py0 = geo.pin_cy if row_num != 2 else geo.row2_pin_cy
-        dx, dy = px0 - cx0, py0 - cy0
-        rdx, rdy = _rotate_cw(dx, dy, ori)
+        return _rotate_cw(px0 - cx0, py0 - cy0, ori)
+
+    def _pin_pos(pin_idx: int) -> tuple[float, float]:
+        rdx, rdy = _pin_offset(pin_idx)
         return conn_cx + rdx, conn_cy + rdy
 
     # ── Effective pinout directions ──
@@ -450,6 +454,13 @@ def render_connector_svg(connector: Connector, conn_type: ConnectorType) -> str:
         ll = r2_line if row_num == 2 else r1_line
         label_extent = text_h if eff in ("bottom", "top") else max_text_w
         pad[eff] = max(pad[eff], ll + label_steps[i] * text_h + label_extent)
+        if eff in ("bottom", "top"):
+            # Middle-anchored labels extend horizontally past the body on edge
+            # pins; widen the side paddings by the overhang so they aren't cropped.
+            half_w = len(pins[i].name) * font_sz * char_w / 2 + 2
+            rdx, _ = _pin_offset(i)
+            pad["left"] = max(pad["left"], margin + half_w - (rot_w / 2 + rdx))
+            pad["right"] = max(pad["right"], margin + half_w - (rot_w / 2 - rdx))
 
     svg_w = pad["left"] + rot_w + pad["right"]
     svg_h = pad["top"] + rot_h + pad["bottom"]

--- a/pinout_gen/pinout_gen/renderer.py
+++ b/pinout_gen/pinout_gen/renderer.py
@@ -664,7 +664,7 @@ _HTML_TEMPLATE = '''\
   --line-color:#888; --label-color:#ddd;
   --desc-color:#aaa; --type-color:#888;
 }}}}
-[data-theme="dark"]{{
+:root[data-theme="dark"]{{
   --bg:#131313; --text:#e0e0e0;
   --tip-bg:#1e1e1e; --tip-border:#3a3a3a; --tip-shadow:rgba(0,0,0,.4);
   --hs-hover:rgba(96,165,250,.15); --hs-stroke:rgba(96,165,250,.5);
@@ -674,6 +674,17 @@ _HTML_TEMPLATE = '''\
   --conn-body:#3a3a35; --conn-cavity:#2e2e28; --conn-stroke:#aaa;
   --line-color:#888; --label-color:#ddd;
   --desc-color:#aaa; --type-color:#888;
+}}
+:root[data-theme="light"]{{
+  --bg:#ffffff; --text:#1a1a1a;
+  --tip-bg:#ffffff; --tip-border:#d0d0d0; --tip-shadow:rgba(0,0,0,.12);
+  --hs-hover:rgba(59,130,246,.13); --hs-stroke:rgba(59,130,246,.5);
+  --hs-active:rgba(59,130,246,.22);
+  --hint-bg:rgba(30,30,30,.75); --hint-text:#fff;
+  --divider:#e5e5e5;
+  --conn-body:#e8e8e0; --conn-cavity:#d0d0c8; --conn-stroke:#555;
+  --line-color:#777; --label-color:#333;
+  --desc-color:#555; --type-color:#888;
 }}
 *,*::before,*::after{{margin:0;padding:0;box-sizing:border-box}}
 html,body{{height:100%;background:var(--bg);color:var(--text);
@@ -691,8 +702,12 @@ body{{display:flex;height:100%;overflow:hidden}}
 .tt{{position:absolute;background:var(--tip-bg);border:1px solid var(--tip-border);
   border-radius:10px;padding:14px 16px;box-shadow:0 6px 20px var(--tip-shadow);
   z-index:1000;opacity:0;pointer-events:none;transition:opacity .15s ease;
-  max-width:min(420px,90vw);line-height:1.4;font-family:Roboto,sans-serif}}
-.tt.vis{{opacity:1;pointer-events:auto}}
+  max-width:min(420px,calc(100vw - 12px));max-height:calc(100vh - 16px);
+  overflow-y:auto;overscroll-behavior:contain;
+  line-height:1.4;font-family:Roboto,sans-serif}}
+.tt.vis{{opacity:1}}
+.tt.pin{{pointer-events:auto}}
+.tt-s svg{{max-width:100%;max-height:min(300px,55vh);width:auto;height:auto}}
 .tt-h{{display:flex;justify-content:space-between;align-items:baseline;gap:12px;
   margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid var(--divider)}}
 .tt-n{{font-weight:600;font-size:14px;color:var(--text)}}
@@ -727,6 +742,51 @@ body{{display:flex;height:100%;overflow:hidden}}
 .cl-n{{font-weight:500;font-size:13px}}
 .cl-t{{font-size:11px;color:var(--type-color);white-space:nowrap}}
 </style>
+<script>
+/* Theme sync: ?theme=dark|light forces a theme; otherwise follow the embedding
+   page's toggle (MkDocs Material / Zensical set data-md-color-scheme on body,
+   "slate" = dark) via same-origin parent access + MutationObserver, or a
+   {{pinconnectTheme:"dark"|"light"}} postMessage for cross-origin embeds.
+   With no signal, data-theme stays unset and prefers-color-scheme applies. */
+(function(){{
+  var root=document.documentElement;
+  function apply(t){{
+    if(t==='dark'||t==='light')root.setAttribute('data-theme',t);
+    else root.removeAttribute('data-theme');
+  }}
+  window.addEventListener('message',function(e){{
+    if(e.data&&typeof e.data==='object'&&'pinconnectTheme' in e.data)apply(e.data.pinconnectTheme);
+  }});
+  var forced=null;
+  try{{forced=new URLSearchParams(location.search).get('theme')}}catch(err){{}}
+  if(forced==='dark'||forced==='light'){{apply(forced);return}}
+  function fromParent(){{
+    try{{
+      if(window.parent===window)return null;
+      var pd=window.parent.document;
+      var md=(pd.body&&pd.body.getAttribute('data-md-color-scheme'))||
+             pd.documentElement.getAttribute('data-md-color-scheme');
+      if(md)return md==='slate'?'dark':'light';
+      var dt=pd.documentElement.getAttribute('data-theme')||
+             (pd.body&&pd.body.getAttribute('data-theme'));
+      if(dt==='dark'||dt==='light')return dt;
+      if(pd.documentElement.classList.contains('dark')||
+         (pd.body&&pd.body.classList.contains('dark')))return 'dark';
+      return null;
+    }}catch(err){{return null}}
+  }}
+  function sync(){{var t=fromParent();if(t)apply(t)}}
+  sync();
+  try{{
+    if(window.parent!==window){{
+      var pd=window.parent.document;
+      var mo=new MutationObserver(sync);
+      mo.observe(pd.documentElement,{{attributes:true}});
+      if(pd.body)mo.observe(pd.body,{{attributes:true}});
+    }}
+  }}catch(err){{}}
+}})();
+</script>
 </head>
 <body>
 <div class="bd">
@@ -768,9 +828,9 @@ function show(id,el){{
   tt.innerHTML=`<div class="tt-h"><span class="tt-n">${{d.name}}</span>`+
     `<span class="tt-t">${{d.typeName}} · ${{d.pinCount}}-pin</span></div>`+
     `<div class="tt-s">${{d.svg}}</div>`+dh;
-  pos(el); tt.classList.add('vis'); aId=id;
+  pos(el); tt.classList.add('vis'); tt.classList.toggle('pin',pinned); aId=id;
 }}
-function hide(){{tt.classList.remove('vis');unmark();aId=null;pinned=false}}
+function hide(){{tt.classList.remove('vis','pin');unmark();aId=null;pinned=false}}
 function pos(el){{
   tt.style.left='0';tt.style.top='0';tt.style.visibility='hidden';tt.classList.add('vis');
   const wr=pw.getBoundingClientRect(),tr=tt.getBoundingClientRect();


### PR DESCRIPTION
This PR fixes a bunch of bugs:
- pinout-gen: Barrier connector: One file had the previous name, updated
- pinout-design: Added connector box as states to fix undo/redo bug
- pinout-design: TOML now updates when image is loaded.
- pinout-design: Connector ID changes handled better
- pinout-gen: Tooltip flickered when larger than the iframe. This broke hover in some cases, fixed.
- pinout-design: Pin labels used to get cropped sometimes, fixed.
- pinout-design: Strings with certain characters no longer corrupt (html escapes)