### PR TITLE
Tooltip scaling & bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ The project works and generates great looking pinouts already. Below are changes
 
 - Add female Sherlock connectors
 - Add slide switch as a "connector" for highlighting its positions
-- Add theming to `pinout-gen` 
 - Update font of `pinout-design` to match the default `pinout-gen` theme (switch to Roboto)
 - Add a screenshot of the output to this document
 

--- a/docs/pinout-gen/themes.md
+++ b/docs/pinout-gen/themes.md
@@ -116,6 +116,8 @@ weights = "400;500"
 | `symbol_style_fallback` | `false` | Give symbol-less connectors a default icon based on their type's style |
 | `font_scale` | `1.0` | Scale the list / tooltip / bottom-bar text |
 | `symbol_size` | `16` | Connector-symbol icon size in px |
+| `tooltip_box_scale` | `1.5` | Tooltip drawing's long side, as a multiple of the connector's box on the board. `0` pins it to its natural size |
+| `tooltip_min_scale` | `0.5` | Smallest fraction of natural size the drawing may shrink to |
 
 ```toml
 [behavior]
@@ -124,6 +126,8 @@ sidebar_responsive_stack = true
 sidebar_stack_breakpoint = 720
 font_scale               = 1.1
 ```
+
+> **Tooltip sizing.** The connector drawing in a tooltip is sized from the connector's box on the board rather than a fixed pixel size, so it shrinks along with the board instead of covering it on a small screen. It tracks the board live — resizing the window or opening the list re-fits the open tooltip. Two bounds keep it sane: it never grows past the drawing's natural size (so wide screens look exactly as they did before), and never shrinks below `tooltip_min_scale` of it (so pin labels stay readable). Raise `tooltip_box_scale` for larger tooltips, or set it to `0` to opt out entirely.
 
 > **Responsive stacking and embedding.** When the list stacks below the board, the pinout resizes itself to fit. If you embed it with [pinout-embed](../pinout-embed/mkdocs-zensical.md), the iframe grows and shrinks to match — no fixed-height scrollbars. Use a recent `pinout-embed` build for this.
 

--- a/pinout_design/css/style.css
+++ b/pinout_design/css/style.css
@@ -226,10 +226,14 @@ html, body {
   height: 100%;
 }
 
+/* --chrome-k (set by BoardPanel to 1/zoom) keeps strokes, labels and handles a
+   constant on-screen size regardless of the board image's pixel resolution:
+   the overlay is drawn in image-pixel units and the wrapper is scaled by zoom,
+   so multiplying by 1/zoom cancels that scaling. */
 .board-rect {
   fill: var(--hs-fill);
   stroke: var(--hs-stroke);
-  stroke-width: 2;
+  stroke-width: calc(2 * var(--chrome-k, 1));
   cursor: pointer;
   transition: fill 0.15s, stroke 0.15s;
 }
@@ -242,12 +246,12 @@ html, body {
 .board-rect.selected {
   fill: var(--hs-fill-selected);
   stroke: var(--hs-stroke-selected);
-  stroke-width: 2.5;
+  stroke-width: calc(2.5 * var(--chrome-k, 1));
 }
 
 .board-rect-label {
   fill: var(--text);
-  font-size: 14px;
+  font-size: calc(14px * var(--chrome-k, 1));
   font-weight: 600;
   pointer-events: none;
   text-anchor: middle;

--- a/pinout_design/js/board-panel.js
+++ b/pinout_design/js/board-panel.js
@@ -60,6 +60,8 @@ export class BoardPanel {
       this._panX = mx - (mx - this._panX) * (this._zoom / oldZoom);
       this._panY = my - (my - this._panY) * (this._zoom / oldZoom);
       this._applyTransform();
+      // Handle geometry is baked in at draw time, so re-draw at the new scale.
+      if (this._zoom !== oldZoom) this._highlightSelected(this.state.selectedConnectorId);
     }, { passive: false });
 
     this.container.addEventListener("mousedown", (e) => {
@@ -86,9 +88,16 @@ export class BoardPanel {
     this.container.addEventListener("contextmenu", (e) => e.preventDefault());
   }
 
+  // Screen-px-to-image-px factor for overlay chrome: the wrapper is scaled by
+  // zoom, so 1/zoom cancels it, keeping strokes/labels/handles a constant size.
+  _chromeK() {
+    return this._zoom > 0 ? 1 / this._zoom : 1;
+  }
+
   _applyTransform() {
     if (!this.wrapper) return;
     this.wrapper.style.transform = `translate(${this._panX}px, ${this._panY}px) scale(${this._zoom})`;
+    this.wrapper.style.setProperty("--chrome-k", this._chromeK());
   }
 
   fitToView() {
@@ -102,6 +111,8 @@ export class BoardPanel {
     this._panX = (vw - bw * this._zoom) / 2;
     this._panY = (vh - bh * this._zoom) / 2;
     this._applyTransform();
+    // Zoom changed after any rects were drawn, so re-scale the handles.
+    this._highlightSelected(this.state.selectedConnectorId);
   }
 
   _bindState() {
@@ -345,9 +356,10 @@ export class BoardPanel {
     this._previewRect.setAttribute("class", "draw-preview");
     this._previewRect.setAttribute("fill", "none");
     this._previewRect.setAttribute("stroke", "var(--accent)");
-    this._previewRect.setAttribute("stroke-width", "2");
-    this._previewRect.setAttribute("stroke-dasharray", "8 4");
-    this._previewRect.setAttribute("rx", "3");
+    const k = this._chromeK();
+    this._previewRect.setAttribute("stroke-width", 2 * k);
+    this._previewRect.setAttribute("stroke-dasharray", `${8 * k} ${4 * k}`);
+    this._previewRect.setAttribute("rx", 3 * k);
     this.svg.appendChild(this._previewRect);
   }
 
@@ -505,7 +517,8 @@ export class BoardPanel {
 
   _addHandles(g, x, y, w, h) {
     const ns = "http://www.w3.org/2000/svg";
-    const hs = HANDLE_SIZE;
+    const k = this._chromeK();
+    const hs = HANDLE_SIZE * k;
     const positions = [
       { handle: "tl", cx: x, cy: y },
       { handle: "t",  cx: x + w / 2, cy: y },
@@ -527,8 +540,8 @@ export class BoardPanel {
       r.setAttribute("height", hs);
       r.setAttribute("fill", "var(--accent)");
       r.setAttribute("stroke", "#fff");
-      r.setAttribute("stroke-width", "1");
-      r.setAttribute("rx", "2");
+      r.setAttribute("stroke-width", 1 * k);
+      r.setAttribute("rx", 2 * k);
       r.style.cursor = this._handleCursor(p.handle);
       g.appendChild(r);
     }

--- a/pinout_design/js/board-panel.js
+++ b/pinout_design/js/board-panel.js
@@ -21,6 +21,16 @@ export class BoardPanel {
     this._bindState();
     this._bindDrawButton();
     this._bindViewportEvents();
+    this._bindGlobalDragEvents();
+  }
+
+  _bindGlobalDragEvents() {
+    // Continue and finish drags at the document level so a drag is never
+    // stranded when the button is released outside the SVG (past the board
+    // edge, over a panel, over the toolbar, or outside the window). Bound
+    // once; both handlers no-op unless a drag started on the board.
+    document.addEventListener("mousemove", (e) => { if (this._drag) this._onMouseMove(e); });
+    document.addEventListener("mouseup", (e) => { if (this._drag) this._onMouseUp(e); });
   }
 
   _bindDrawButton() {
@@ -178,9 +188,10 @@ export class BoardPanel {
   }
 
   _bindSvgEvents() {
+    // Only the drag START and click (selection) are bound to the SVG; movement
+    // and release are handled at the document level (see _bindGlobalDragEvents)
+    // so a drag can't be lost when the pointer leaves the SVG mid-drag.
     this.svg.addEventListener("mousedown", (e) => this._onMouseDown(e));
-    this.svg.addEventListener("mousemove", (e) => this._onMouseMove(e));
-    this.svg.addEventListener("mouseup", (e) => this._onMouseUp(e));
     this.svg.addEventListener("click", (e) => {
       if (!this._drag || !this._drag.moved) {
         const g = e.target.closest("g[data-id]");
@@ -245,6 +256,10 @@ export class BoardPanel {
 
   _onMouseMove(e) {
     if (!this._drag) return;
+    // If the button was released where we never saw the mouseup (outside the
+    // window), the next move arrives with no buttons held. Finalize the drag
+    // instead of letting the connector follow the loose cursor.
+    if (e.buttons === 0) { this._onMouseUp(e); return; }
     const pt = this._svgPoint(e);
     this._drag.moved = true;
 

--- a/pinout_design/js/connector-panel.js
+++ b/pinout_design/js/connector-panel.js
@@ -27,7 +27,18 @@ export class ConnectorPanel {
   _bindState() {
     this.state.on("selection-changed", () => this._render());
     this.state.on("connector-changed", ({ connectorId }) => {
-      if (connectorId === this.state.selectedConnectorId) this._render();
+      if (connectorId !== this.state.selectedConnectorId) return;
+      // A connector field edit fires `change` on blur — so if we rebuilt the
+      // whole panel here, we'd destroy the element the user is clicking (e.g.
+      // "+ Add Pin", a delete button, a swatch) before the click completes,
+      // silently losing it. Only re-render when the pin-row structure actually
+      // changes (dual-row-ness, from a type change); otherwise just refresh the
+      // drawing, leaving the form and the pending click intact.
+      const conn = this.state.getSelectedConnector();
+      const ct = conn && this.state.connectorTypes.get(conn.type);
+      const isDualRow = !!(ct && ct.geometry.rows >= 2);
+      if (isDualRow !== this._isDualRow) this._render();
+      else this._updateSvgPreview();
     });
     this.state.on("pin-changed", ({ connectorId, pinIndex, origin }) => {
       if (connectorId !== this.state.selectedConnectorId) return;
@@ -64,6 +75,7 @@ export class ConnectorPanel {
 
     const ct = this.state.connectorTypes.get(conn.type);
     const isDualRow = ct && ct.geometry.rows >= 2;
+    this._isDualRow = !!isDualRow;
 
     let svgHtml = "";
     if (ct) {

--- a/pinout_design/js/connector-panel.js
+++ b/pinout_design/js/connector-panel.js
@@ -144,7 +144,7 @@ export class ConnectorPanel {
     return `
       <div class="pin-row" data-idx="${index}">
         <span class="pin-drag-handle" draggable="true" data-idx="${index}">≡</span>
-        <div class="pin-color-swatch" data-idx="${index}" style="background:${pin.color}" title="${pin.color}"></div>
+        <div class="pin-color-swatch" data-idx="${index}" style="background:${this._esc(pin.color)}" title="${this._esc(pin.color)}"></div>
         <input type="text" class="pin-name-input" data-idx="${index}" value="${this._esc(pin.name)}">
         ${rowSel}
         <button class="pin-delete-btn" data-idx="${index}">×</button>
@@ -193,9 +193,13 @@ export class ConnectorPanel {
       if (e.key === "Enter") {
         e.preventDefault();
         const hex = hexInput.value.trim();
-        if (/^[0-9A-Fa-f]{3,6}$/.test(hex)) {
+        // Only 3- or 6-digit hex is a valid solid color; 4/5-digit values used
+        // to be accepted and stored as invalid colors.
+        if (/^([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/.test(hex)) {
           this._applyColor(swatchEl, connId, pinIndex, "#" + hex);
           this._closePopup();
+        } else {
+          hexInput.style.borderColor = "var(--danger)";
         }
       }
       e.stopPropagation();

--- a/pinout_design/js/editor-panel.js
+++ b/pinout_design/js/editor-panel.js
@@ -1,4 +1,4 @@
-import { parseBoardToml, buildSourceMap, serializeBoardToml, patchConnectorInSource, TomlParseError } from "./toml-io.js";
+import { parseBoardToml, buildSourceMap, serializeBoardToml, serializeConnectorBlock, patchConnectorInSource, TomlParseError } from "./toml-io.js";
 import { Board, Connector, Pin } from "./board-model.js";
 
 function esc(s) {
@@ -122,23 +122,19 @@ export class EditorPanel {
       this._patchConnector(connectorId);
     });
 
-    this.state.on("connector-added", ({ origin }) => {
+    this.state.on("connector-added", ({ connectorId, origin }) => {
       if (origin === "editor") return;
-      this._suppressSync = true;
-      this._syncFromState();
-      this._suppressSync = false;
+      this._appendConnector(connectorId);
     });
 
-    this.state.on("connector-removed", ({ origin }) => {
+    this.state.on("connector-removed", ({ connectorId, origin }) => {
       if (origin === "editor") return;
-      this._suppressSync = true;
-      this._syncFromState();
-      this._suppressSync = false;
+      this._removeConnectorFromSource(connectorId);
     });
 
-    this.state.on("connector-renamed", ({ newId, origin }) => {
+    this.state.on("connector-renamed", ({ oldId, newId, origin }) => {
       if (origin === "editor") return;
-      this._patchConnector(newId);
+      this._patchConnector(newId, oldId);
     });
 
     this.state.on("pin-changed", ({ connectorId, origin }) => {
@@ -233,29 +229,67 @@ export class EditorPanel {
     this._updateHighlight();
   }
 
-  _patchConnector(connectorId) {
-    const text = this.textarea.value;
-    const sourceMap = buildSourceMap(text);
-    const idx = this.state.getConnectorIndex(connectorId);
-    if (idx < 0 || !sourceMap.connectors[idx]) {
-      this._suppressSync = true;
-      this._syncFromState();
-      this._suppressSync = false;
-      return;
-    }
-
-    const conn = this.state.getConnector(connectorId);
-    const connData = {
+  _connData(conn) {
+    return {
       id: conn.id, name: conn.name, type: conn.type,
       x1: conn.x1, y1: conn.y1, x2: conn.x2, y2: conn.y2,
       orientation: conn.orientation, description: conn.description,
       label_style: conn.label_style, symbol: conn.symbol,
       pins: conn.pins.map(p => ({ name: p.name, color: p.color, row: p.row })),
     };
+  }
+
+  // Rewrite one connector's block in place. Locate it by the id it currently
+  // carries in the text (lookupId — the OLD id on a rename), not by state-array
+  // position: text and state can be ordered differently, and patching the
+  // wrong block would corrupt an unrelated connector.
+  _patchConnector(connectorId, lookupId = connectorId) {
+    const text = this.textarea.value;
+    const range = buildSourceMap(text).connectors.find(c => c.id === lookupId);
+    const conn = this.state.getConnector(connectorId);
+    if (!range || !conn) {
+      this._suppressSync = true;
+      this._syncFromState();
+      this._suppressSync = false;
+      return;
+    }
 
     this._suppressSync = true;
-    const newText = patchConnectorInSource(text, sourceMap, idx, connData);
-    this.textarea.value = newText;
+    this.textarea.value = patchConnectorInSource(text, range, this._connData(conn));
+    this._updateHighlight();
+    this._suppressSync = false;
+  }
+
+  // Append a newly-added connector's block rather than regenerating the whole
+  // document, so hand-written comments and formatting elsewhere survive.
+  _appendConnector(connectorId) {
+    const conn = this.state.getConnector(connectorId);
+    if (!conn) return;
+    let text = this.textarea.value;
+    if (text && !text.endsWith("\n")) text += "\n";
+    this._suppressSync = true;
+    this.textarea.value = text + "\n" + serializeConnectorBlock(this._connData(conn)) + "\n";
+    this._updateHighlight();
+    this._suppressSync = false;
+  }
+
+  // Delete just the removed connector's block (found by id), plus one blank
+  // separator above it, leaving the rest of the document — including comments —
+  // untouched. The connector is already gone from state, so match on the text.
+  _removeConnectorFromSource(connectorId) {
+    const text = this.textarea.value;
+    const range = buildSourceMap(text).connectors.find(c => c.id === connectorId);
+    if (!range) {
+      this._suppressSync = true;
+      this._syncFromState();
+      this._suppressSync = false;
+      return;
+    }
+    const lines = text.split("\n");
+    let from = range.start;
+    if (from > 0 && lines[from - 1].trim() === "") from--;
+    this._suppressSync = true;
+    this.textarea.value = [...lines.slice(0, from), ...lines.slice(range.end + 1)].join("\n");
     this._updateHighlight();
     this._suppressSync = false;
   }

--- a/pinout_design/js/svg-renderer.js
+++ b/pinout_design/js/svg-renderer.js
@@ -348,7 +348,10 @@ export function renderConnectorSVG(connector, connType) {
   const geo = connType.geometry;
   const pins = connector.pins;
   const n = pins.length;
-  const ori = connector.orientation % 360;
+  // Normalize to [0,360). JS's % keeps the sign of the dividend, so a negative
+  // orientation (e.g. -90) would give a negative index into `sides` below,
+  // yielding sides[-1] = undefined and forcing every label off-canvas.
+  const ori = ((connector.orientation % 360) + 360) % 360;
 
   const r1Global = [], r2Global = [];
   for (let i = 0; i < n; i++) {
@@ -546,7 +549,7 @@ export function renderConnectorSVG(connector, connType) {
     const ll = rowNum === 2 ? r2Line : r1Line;
     const stairOffset = labelSteps.get(i) * textH;
     const [rpx, rpy] = pinPos(i);
-    const col = pins[i].color;
+    const col = escapeHtml(pins[i].color);
     let lx2, ly2;
     if (eff === "bottom")     { lx2 = rpx; ly2 = bodyBot + ll + stairOffset; }
     else if (eff === "top")   { lx2 = rpx; ly2 = bodyTop - ll - stairOffset; }
@@ -566,7 +569,7 @@ export function renderConnectorSVG(connector, connType) {
     const ll = rowNum === 2 ? r2Line : r1Line;
     const stairOffset = labelSteps.get(i) * textH;
     const [rpx, rpy] = pinPos(i);
-    const col = pins[i].color;
+    const col = escapeHtml(pins[i].color);
     const name = escapeHtml(pins[i].name);
 
     const pr = (rowNum === 2 && geo.row2_pin_radius >= 0) ? geo.row2_pin_radius : geo.pin_radius;

--- a/pinout_design/js/toml-io.js
+++ b/pinout_design/js/toml-io.js
@@ -132,14 +132,17 @@ function parseInlineArray(val, lineNum) {
 export function parseBoardToml(text) {
   const raw = parseToml(text);
   const b = raw.board || {};
+  // Use ?? (not ||) for fields with a non-empty default, so an explicit empty
+  // string the user typed (e.g. title = "") survives the round-trip instead of
+  // being silently replaced by the default.
   const board = {
-    title: b.title || "Pinout",
-    image: b.image || "",
+    title: b.title ?? "Pinout",
+    image: b.image ?? "",
     width: b.width || 0,
     height: b.height || 0,
-    connector_dir: b.connector_dir || "./connectors",
-    theme: b.theme || "default",
-    theme_dir: b.theme_dir || "./themes",
+    connector_dir: b.connector_dir ?? "./connectors",
+    theme: b.theme ?? "default",
+    theme_dir: b.theme_dir ?? "./themes",
   };
 
   const connectors = (raw.connector || []).map(c => ({
@@ -169,40 +172,55 @@ export function parseBoardToml(text) {
 export function buildSourceMap(text) {
   const lines = text.split("\n");
   const map = { board: null, connectors: [] };
+  let scope = null;          // "board" | "connector" | "pin" | null
   let currentConn = null;
   let currentPin = null;
 
   for (let i = 0; i < lines.length; i++) {
-    const trimmed = lines[i].trim();
+    // Classify on the comment-stripped, trimmed line. A blank or comment-only
+    // line is never part of a block's range, so ranges end at the last real
+    // content line — trailing blanks/comments between blocks are preserved.
+    const trimmed = stripComment(lines[i]).trim();
+    if (!trimmed) continue;
 
-    if (trimmed.startsWith("[board]")) {
+    if (trimmed === "[board]") {
       map.board = { start: i, end: i };
+      scope = "board"; currentConn = null; currentPin = null;
       continue;
     }
-
     if (trimmed === "[[connector]]") {
-      if (currentConn) currentConn.end = i - 1;
-      currentConn = { start: i, end: i, pins: [] };
-      currentPin = null;
+      currentConn = { start: i, end: i, id: null, pins: [] };
+      currentPin = null; scope = "connector";
       map.connectors.push(currentConn);
       continue;
     }
-
     if (trimmed === "[[connector.pin]]") {
       currentPin = { start: i, end: i };
-      if (currentConn) currentConn.pins.push(currentPin);
+      scope = "pin";
+      if (currentConn) { currentConn.pins.push(currentPin); currentConn.end = i; }
+      continue;
+    }
+    if (trimmed.startsWith("[")) {
+      // Any other table header closes the current block, so its lines aren't
+      // swallowed into the previous connector's (or board's) range.
+      scope = null; currentConn = null; currentPin = null;
       continue;
     }
 
-    if (currentPin) currentPin.end = i;
-    else if (currentConn) currentConn.end = i;
-    else if (map.board) map.board.end = i;
-  }
-
-  if (currentConn) {
-    currentConn.end = lines.length - 1;
-    while (currentConn.end > currentConn.start && !lines[currentConn.end].trim()) {
-      currentConn.end--;
+    // A key = value content line extends only the innermost open block.
+    if (scope === "pin" && currentPin) {
+      currentPin.end = i;
+      if (currentConn) currentConn.end = i;
+    } else if (scope === "connector" && currentConn) {
+      currentConn.end = i;
+      if (currentConn.id === null) {
+        const m = trimmed.match(/^id\s*=\s*(.+)$/);
+        if (m) {
+          try { currentConn.id = parseTomlValue(m[1].trim(), i + 1); } catch { /* leave null */ }
+        }
+      }
+    } else if (scope === "board" && map.board) {
+      map.board.end = i;
     }
   }
 
@@ -272,15 +290,11 @@ export function serializeBoardToml(boardData, connectors) {
   return lines.join("\n") + "\n";
 }
 
-export function patchConnectorInSource(sourceText, sourceMap, connIndex, newConn) {
-  const lines = sourceText.split("\n");
-  const range = sourceMap.connectors[connIndex];
+export function patchConnectorInSource(sourceText, range, newConn) {
   if (!range) return sourceText;
-
-  const newBlock = serializeConnectorBlock(newConn);
-  const newLines = newBlock.split("\n");
+  const lines = sourceText.split("\n");
+  const newLines = serializeConnectorBlock(newConn).split("\n");
   const before = lines.slice(0, range.start);
   const after = lines.slice(range.end + 1);
-
   return [...before, ...newLines, ...after].join("\n");
 }

--- a/pinout_embed/pinout_embed.py
+++ b/pinout_embed/pinout_embed.py
@@ -108,8 +108,16 @@ class PinoutHeightPostprocessor(Postprocessor):
 
 class PinoutExtension(Extension):
     def extendMarkdown(self, md):
+        # Negative priority so this runs AFTER the host's relative-path pass.
+        # MkDocs' `relpath` treeprocessor (priority 0) rewrites relative links,
+        # but only on <a href>/<img src>. If we converted <img> to <iframe>
+        # first (as at priority 1), relpath would skip the iframe and its
+        # relative src would 404 under use_directory_urls (the default). Running
+        # later lets relpath resolve the <img src>, which we then carry onto the
+        # iframe. Zensical rewrites every element's src regardless of order, so
+        # it is unaffected either way.
         md.treeprocessors.register(
-            PinoutTreeprocessor(md), "pinout_embed", 1
+            PinoutTreeprocessor(md), "pinout_embed", -5
         )
         md.postprocessors.register(
             PinoutHeightPostprocessor(md), "pinout_embed_height", 1

--- a/pinout_embed/pinout_embed.py
+++ b/pinout_embed/pinout_embed.py
@@ -24,6 +24,13 @@ EMBED_CLASS = "pinconnect-embed"
 # works with several pinouts on a page), sets the height on a positive value,
 # and clears it on 0 so the iframe reverts to its authored height on wide
 # screens.  A sanity cap ignores absurd values.
+#
+# The second block flags a broken embed instead of shipping a silently-blank
+# iframe: a same-origin HEAD that returns 404 means the target file is missing
+# (a typo, or the pinout was never generated), so the iframe is replaced with a
+# visible error.  MkDocs reports this at build time; Zensical (and plain
+# Markdown) do not, so this covers them at runtime.  Cross-origin embeds can't
+# be checked (CORS) and are left untouched.
 _LISTENER_SCRIPT = (
     "\n<script>\n"
     "(function(){\n"
@@ -47,6 +54,21 @@ _LISTENER_SCRIPT = (
     "        break;\n"
     "      }\n"
     "    }\n"
+    "  });\n"
+    "  Array.prototype.forEach.call(document.querySelectorAll('iframe." + EMBED_CLASS + "'),function(f){\n"
+    "    var src=f.getAttribute('src');if(!src)return;\n"
+    "    fetch(src,{method:'HEAD'}).then(function(r){\n"
+    "      if(r.status!==404)return;\n"
+    "      var d=document.createElement('div');\n"
+    "      d.className='" + EMBED_CLASS + "-error';\n"
+    "      d.style.cssText='display:flex;align-items:center;justify-content:center;"
+    "box-sizing:border-box;padding:16px;width:100%;text-align:center;"
+    "border:1px solid #d9534f;border-radius:8px;color:#d9534f;"
+    "font-family:system-ui,sans-serif;font-size:14px;background:rgba(217,83,79,.06);';\n"
+    "      d.style.minHeight=f.style.minHeight;\n"
+    "      d.textContent='\\u26A0 Pinout failed to load \\u2014 file not found: '+src;\n"
+    "      f.replaceWith(d);\n"
+    "    }).catch(function(){});\n"
     "  });\n"
     "})();\n"
     "</script>"

--- a/pinout_gen/pinout_gen/cli.py
+++ b/pinout_gen/pinout_gen/cli.py
@@ -68,10 +68,10 @@ def main(argv: list[str] | None = None) -> None:
 
     try:
         board = load_board(config_path)
-    except ValueError as e:
+        connector_types = load_all_connector_types(board, config_path)
+    except (ValueError, FileNotFoundError) as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
-    connector_types = load_all_connector_types(board, config_path)
 
     theme_name = args.theme or board.theme
     try:

--- a/pinout_gen/pinout_gen/cli.py
+++ b/pinout_gen/pinout_gen/cli.py
@@ -66,7 +66,11 @@ def main(argv: list[str] | None = None) -> None:
         print(f"Error: config file not found: {config_path}", file=sys.stderr)
         sys.exit(1)
 
-    board = load_board(config_path)
+    try:
+        board = load_board(config_path)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
     connector_types = load_all_connector_types(board, config_path)
 
     theme_name = args.theme or board.theme

--- a/pinout_gen/pinout_gen/config.py
+++ b/pinout_gen/pinout_gen/config.py
@@ -93,24 +93,59 @@ class Board:
 
 # ── Loading ──────────────────────────────────────────────────────────
 
-def load_board(path: Path) -> Board:
-    with open(path, "rb") as f:
-        raw = tomllib.load(f)
+def _require(table: dict, key: str, ctx: str):
+    """Fetch a required key, raising a clear ValueError (not a bare KeyError)
+    naming the missing field and where it belongs. The board TOML is meant to
+    be hand-editable, so a missing key must read as a message, not a traceback.
+    """
+    try:
+        return table[key]
+    except (KeyError, TypeError):
+        raise ValueError(f"{ctx}: missing required key '{key}'") from None
 
+
+def load_board(path: Path) -> Board:
+    try:
+        with open(path, "rb") as f:
+            raw = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ValueError(f"invalid TOML in {path.name}: {e}") from None
+
+    if "board" not in raw:
+        raise ValueError(f"{path.name}: missing required [board] table")
     b = raw["board"]
+
+    width = _require(b, "width", "[board]")
+    height = _require(b, "height", "[board]")
+    image = _require(b, "image", "[board]")
+    for dim, val in (("width", width), ("height", height)):
+        if isinstance(val, bool) or not isinstance(val, (int, float)) or val <= 0:
+            raise ValueError(
+                f"[board]: {dim} must be a positive number (got {val!r}); "
+                f"set width/height to the board image's pixel dimensions"
+            )
+    if not image:
+        raise ValueError("[board]: 'image' must name the board image the pinout overlays")
+
     board = Board(
         title=b.get("title", "Pinout"),
-        image=b["image"],
-        width=b["width"],
-        height=b["height"],
+        image=image, width=width, height=height,
         connector_dir=b.get("connector_dir", "./connectors"),
         theme=b.get("theme", "default"),
         theme_dir=b.get("theme_dir", "./themes"),
     )
 
+    connectors_raw = raw.get("connector", [])
+    if isinstance(connectors_raw, dict):
+        # A single `[connector]` table instead of `[[connector]]` (array of
+        # tables) is a classic TOML slip; tomllib parses it as a dict.
+        raise ValueError(
+            "connectors must be written as '[[connector]]' (an array of tables), not '[connector]'"
+        )
+
     seen_ids: set[str] = set()
-    for c in raw.get("connector", []):
-        cid = c["id"]
+    for i, c in enumerate(connectors_raw):
+        cid = _require(c, "id", f"[[connector]] #{i + 1}")
         # Ids key the connector data, the hotspot rects, and the sidebar entries
         # in the generated page; a duplicate would silently overwrite one
         # connector's pinout and mis-target hover/click. Reject it up front.
@@ -119,13 +154,17 @@ def load_board(path: Path) -> Board:
                 f"duplicate connector id '{cid}': every [[connector]] must have a unique id"
             )
         seen_ids.add(cid)
+        ctx = f"connector '{cid}'"
         pins = [
-            Pin(name=p["name"], color=p.get("color", "#888888"), row=p.get("row", 1))
-            for p in c.get("pin", [])
+            Pin(name=_require(p, "name", f"{ctx} pin #{j + 1}"),
+                color=p.get("color", "#888888"), row=p.get("row", 1))
+            for j, p in enumerate(c.get("pin", []))
         ]
         board.connectors.append(Connector(
-            id=cid, name=c["name"], type=c["type"], pins=pins,
-            x1=c["x1"], y1=c["y1"], x2=c["x2"], y2=c["y2"],
+            id=cid,
+            name=_require(c, "name", ctx), type=_require(c, "type", ctx), pins=pins,
+            x1=_require(c, "x1", ctx), y1=_require(c, "y1", ctx),
+            x2=_require(c, "x2", ctx), y2=_require(c, "y2", ctx),
             orientation=c.get("orientation", 0),
             description=c.get("description", ""),
             label_style=c.get("label_style", "staggered"),
@@ -135,19 +174,39 @@ def load_board(path: Path) -> Board:
 
 
 def load_connector_type(path: Path) -> ConnectorType:
-    with open(path, "rb") as f:
-        raw = tomllib.load(f)
+    try:
+        with open(path, "rb") as f:
+            raw = tomllib.load(f)
+    except tomllib.TOMLDecodeError as e:
+        raise ValueError(f"invalid TOML in {path.name}: {e}") from None
 
+    if "connector" not in raw:
+        raise ValueError(f"{path.name}: missing required [connector] table")
     info = raw["connector"]
     geo_raw = raw.get("geometry", {})
-    geo = ConnectorGeometry(**{
-        k: v for k, v in geo_raw.items()
-        if k in ConnectorGeometry.__dataclass_fields__
-    })
+
+    # A misspelled geometry key used to be silently dropped, so the field kept
+    # its default and the connector drew wrong with no warning. Reject unknown
+    # keys, and coerce each value to its field's type so a wrong-typed value is
+    # a clear error here rather than a deep TypeError during rendering.
+    fields = ConnectorGeometry.__dataclass_fields__
+    unknown = sorted(k for k in geo_raw if k not in fields)
+    if unknown:
+        raise ValueError(f"{path.name}: unknown [geometry] key(s): {', '.join(unknown)}")
+    geo_kwargs = {}
+    for k, v in geo_raw.items():
+        target = type(fields[k].default)
+        try:
+            geo_kwargs[k] = target(v)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"{path.name}: [geometry] '{k}' must be {target.__name__}, got {v!r}"
+            ) from None
+
     return ConnectorType(
-        name=info["name"],
+        name=_require(info, "name", f"{path.name} [connector]"),
         style=info.get("style", "box"),
-        geometry=geo,
+        geometry=ConnectorGeometry(**geo_kwargs),
     )
 
 

--- a/pinout_gen/pinout_gen/config.py
+++ b/pinout_gen/pinout_gen/config.py
@@ -221,6 +221,10 @@ class ThemeBehavior:
     symbol_style_fallback: bool = False      # symbol-less connectors fall back to a style default
     font_scale: float = 1.0                  # multiplier for the list / tooltip / bottom-bar text
     symbol_size: int = 16                    # connector-symbol icon size in px
+    tooltip_box_scale: float = 1.5           # tooltip drawing's long side, as a multiple of the
+                                             # connector's on-screen box; 0 disables (natural size)
+    tooltip_min_scale: float = 0.5           # never shrink the drawing below this fraction of its
+                                             # natural size, so pin labels stay readable
 
 
 @dataclass
@@ -316,6 +320,9 @@ def load_theme(name: str, board_path: Path, theme_dir: str = "./themes") -> Them
         beh.symbol_style_fallback = bool(bdict.get("symbol_style_fallback", beh.symbol_style_fallback))
         beh.font_scale = float(bdict.get("font_scale", beh.font_scale))
         beh.symbol_size = int(bdict.get("symbol_size", beh.symbol_size))
+        beh.tooltip_box_scale = max(0.0, float(bdict.get("tooltip_box_scale", beh.tooltip_box_scale)))
+        beh.tooltip_min_scale = min(1.0, max(0.0, float(
+            bdict.get("tooltip_min_scale", beh.tooltip_min_scale))))
 
     extra = raw.get("extra_css", {})
     if isinstance(extra, dict):

--- a/pinout_gen/pinout_gen/config.py
+++ b/pinout_gen/pinout_gen/config.py
@@ -108,13 +108,23 @@ def load_board(path: Path) -> Board:
         theme_dir=b.get("theme_dir", "./themes"),
     )
 
+    seen_ids: set[str] = set()
     for c in raw.get("connector", []):
+        cid = c["id"]
+        # Ids key the connector data, the hotspot rects, and the sidebar entries
+        # in the generated page; a duplicate would silently overwrite one
+        # connector's pinout and mis-target hover/click. Reject it up front.
+        if cid in seen_ids:
+            raise ValueError(
+                f"duplicate connector id '{cid}': every [[connector]] must have a unique id"
+            )
+        seen_ids.add(cid)
         pins = [
             Pin(name=p["name"], color=p.get("color", "#888888"), row=p.get("row", 1))
             for p in c.get("pin", [])
         ]
         board.connectors.append(Connector(
-            id=c["id"], name=c["name"], type=c["type"], pins=pins,
+            id=cid, name=c["name"], type=c["type"], pins=pins,
             x1=c["x1"], y1=c["y1"], x2=c["x2"], y2=c["y2"],
             orientation=c.get("orientation", 0),
             description=c.get("description", ""),

--- a/pinout_gen/pinout_gen/renderer.py
+++ b/pinout_gen/pinout_gen/renderer.py
@@ -787,6 +787,8 @@ def generate_html(board: Board, connector_types: dict[str, ConnectorType], *,
         sb_hidden="" if theme.behavior.sidebar_default_open else " hid",
         sb_stack="true" if theme.behavior.sidebar_responsive_stack else "false",
         sb_bp=theme.behavior.sidebar_stack_breakpoint,
+        tt_box_scale=theme.behavior.tooltip_box_scale,
+        tt_min_scale=theme.behavior.tooltip_min_scale,
         hotspots='\n'.join(hotspot_rects),
         connector_list='\n'.join(sidebar_items),
         data=data_json,
@@ -981,7 +983,25 @@ function show(id,el){{
   pos(el); tt.classList.add('vis'); tt.classList.toggle('pin',pinned); aId=id;
 }}
 function hide(){{tt.classList.remove('vis','pin');unmark();aId=null;pinned=false}}
+/* Scale the tooltip's connector drawing off the connector's box on the board:
+   the drawing's long side tracks TT_BOX x the box's on-screen long side, so it
+   shrinks with the board instead of holding its generated pixel size and
+   swamping a small screen.  Only the width is set -- the stylesheet's
+   height:auto keeps the aspect ratio and its max-* caps still apply.  Clamped to
+   the natural size (never upscale) and to TT_MIN of it (labels stay readable). */
+const TT_BOX={tt_box_scale},TT_MIN={tt_min_scale};
+function fit(el){{
+  const g=tt.querySelector('.tt-s>svg');if(!g||!TT_BOX)return;
+  const nw=+g.getAttribute('width'),nh=+g.getAttribute('height');
+  const svg=el.ownerSVGElement,sr=svg.getBoundingClientRect(),vb=svg.viewBox.baseVal;
+  if(!(nw>0&&nh>0&&sr.width>0&&vb.width>0&&vb.height>0))return;
+  const box=Math.max(+el.getAttribute('width')*sr.width/vb.width,
+                     +el.getAttribute('height')*sr.height/vb.height);
+  const s=Math.max(TT_MIN,Math.min(1,TT_BOX*box/Math.max(nw,nh)));
+  g.style.width=(nw*s).toFixed(1)+'px';
+}}
 function pos(el){{
+  fit(el);
   tt.style.left='0';tt.style.top='0';tt.style.visibility='hidden';tt.classList.add('vis');
   const wr=pw.getBoundingClientRect(),tr=tt.getBoundingClientRect();
   const svg=el.ownerSVGElement,sr=svg.getBoundingClientRect(),vb=svg.viewBox.baseVal;
@@ -1014,7 +1034,11 @@ document.addEventListener('click',e=>{{
   if(pinned&&!tt.contains(e.target)&&!e.target.closest('.cl-i')&&!e.target.closest('.hs'))hide();
 }});
 document.querySelectorAll('.hs').forEach(el=>{{el.classList.add('pulse');setTimeout(()=>el.classList.remove('pulse'),2000)}});
-window.addEventListener('resize',()=>{{if(aId){{const el=hs(aId);if(el)pos(el)}}}});
+function reflow(){{if(aId){{const el=hs(aId);if(el)pos(el)}}}}
+window.addEventListener('resize',reflow);
+/* The board also resizes without a window resize (sidebar toggle, iframe
+   auto-height, container reflow) -- re-fit the tooltip whenever it does. */
+if(window.ResizeObserver){{try{{new ResizeObserver(reflow).observe(pw)}}catch(e){{}}}}
 </script>
 {height_script}
 </body>

--- a/pinout_gen/pinout_gen/themes/default.toml
+++ b/pinout_gen/pinout_gen/themes/default.toml
@@ -40,6 +40,8 @@ name = "Default"
 # symbol_style_fallback    = false   # symbol-less connectors fall back to a style-based default icon
 # font_scale               = 1.0     # scales the connector list / tooltip / bottom-bar text
 # symbol_size              = 16       # connector-symbol icon size in px
+# tooltip_box_scale        = 1.5     # tooltip drawing's long side vs the connector's box on the board; 0 = natural size
+# tooltip_min_scale        = 0.5     # smallest fraction of natural size the drawing may shrink to
 
 # Colours are CSS values (hex, rgb(), rgba(), …).  `light` applies in light
 # mode, `dark` in dark mode; the viewer's theme toggle and OS scheme both


### PR DESCRIPTION
This PR:
- Adds connector drawing scaling relative to connector box, improving small-screen behavior. Themes can override or change the multiplier
- Bug fix: End canvas drags when the mouse is released off the SVG
- Bug fix: Reject duplicate connector ids in pinout-gen
- Bug fix: Resolve embed iframe paths under MkDocs use_directory_urls
- Bug fix: Clear errors for malformed board and connector-type TOML
- Bug fix: Preserve comments and target the right block in the TOML editor
- Remove theming from readme todo
- Bug fix: Connector hex hardening to not accept bad hex values
- Bug fix: Fix connector box overlay on high-res board images
- Make missing boards not just show an embedded 404 with pinout-embed