### PR TITLE
More bug fixes

### DIFF
--- a/docs/pinout-gen/connector-types.md
+++ b/docs/pinout-gen/connector-types.md
@@ -21,6 +21,7 @@ Type definitions live in `pinout_gen/pinout_gen/connectors/`, one `.toml` file p
 | `MX-F-2R` | grid | Micro-Fit female, two rows |
 | `USB-C` | box | Simple rectangular body |
 | `XT30-2+2` | xt30 | XT30 power + 2 signal pins |
+| `button` | button | Tactile push-button / switch footprint |
 
 `Male` and `Female` refer to the gender of the plastic housing of the connector, not the pins, as that's what the end user will see when using the board.
 
@@ -59,6 +60,7 @@ cavity_size = 10.5
   - `header-male` — a pitch-scaled male pin-header housing with square cavities and keyed joints.
   - `screw-terminal` — a screw-terminal with circular screw heads and side wire-entry slots.
   - `barrier` — a barrier screw-terminal with individual metal cages and cross-drive screws.
+  - `button` — a tactile push-button / switch footprint (a round actuator between two pads).
 
 ### `[geometry]`
 

--- a/pinout_design/js/board-panel.js
+++ b/pinout_design/js/board-panel.js
@@ -142,8 +142,11 @@ export class BoardPanel {
     if (this.svg) {
       this.svg.setAttribute("viewBox", `0 0 ${w} ${h}`);
       if (this.wrapper) {
-        const oldW = parseInt(this.wrapper.style.width);
-        const oldH = parseInt(this.wrapper.style.height);
+        // parseFloat, not parseInt: with a fractional board width/height,
+        // parseInt truncated the stored value so oldW never equalled w and
+        // fitToView reset the user's zoom/pan on every board-changed.
+        const oldW = parseFloat(this.wrapper.style.width);
+        const oldH = parseFloat(this.wrapper.style.height);
         this.wrapper.style.width = w + "px";
         this.wrapper.style.height = h + "px";
         if (oldW !== w || oldH !== h) this.fitToView();
@@ -204,11 +207,14 @@ export class BoardPanel {
     // so a drag can't be lost when the pointer leaves the SVG mid-drag.
     this.svg.addEventListener("mousedown", (e) => this._onMouseDown(e));
     this.svg.addEventListener("click", (e) => {
-      if (!this._drag || !this._drag.moved) {
-        const g = e.target.closest("g[data-id]");
-        if (g) this.state.selectConnector(g.getAttribute("data-id"));
-        else if (!this.drawMode) this.state.selectConnector(null);
-      }
+      // A drag ends with a trailing click, but mouseup has already nulled
+      // _drag, so guard on a flag instead. Without it, a drag that ends over
+      // empty space would run the deselect branch below and wrongly clear the
+      // selection of the connector just dragged.
+      if (this._suppressNextClick) { this._suppressNextClick = false; return; }
+      const g = e.target.closest("g[data-id]");
+      if (g) this.state.selectConnector(g.getAttribute("data-id"));
+      else if (!this.drawMode) this.state.selectConnector(null);
     });
   }
 
@@ -223,6 +229,7 @@ export class BoardPanel {
 
   _onMouseDown(e) {
     if (e.button !== 0) return;
+    this._suppressNextClick = false;
     const pt = this._svgPoint(e);
 
     if (this.drawMode) {
@@ -316,6 +323,8 @@ export class BoardPanel {
     if (!this._drag) return;
     const drag = this._drag;
     this._drag = null;
+    // A drag that actually moved should swallow its trailing click.
+    this._suppressNextClick = drag.moved;
 
     if (drag.type === "draw" && drag.moved) {
       this._removePreviewRect();

--- a/pinout_design/js/connector-panel.js
+++ b/pinout_design/js/connector-panel.js
@@ -280,7 +280,24 @@ export class ConnectorPanel {
 
     onFieldChange("#conn-id", "id");
     onFieldChange("#conn-name", "name");
-    onFieldChange("#conn-type", "type");
+    // Type change gets a custom handler: switching to a single-row type would
+    // strand any row-2 pins (no R2 selector to fix them, mis-rendered at y=0),
+    // so pull them back to row 1 in the same update.
+    const typeEl = this.container.querySelector("#conn-type");
+    if (typeEl) {
+      typeEl.addEventListener("change", () => {
+        const newType = typeEl.value;
+        const c = this.state.getConnector(cid);
+        const ct = this.state.connectorTypes.get(newType);
+        const isDual = !!(ct && ct.geometry.rows >= 2);
+        if (!isDual && c && c.pins.some(p => p.row === 2)) {
+          const pins = c.pins.map(p => new Pin(p.name, p.color, 1));
+          this.state.updateConnector(cid, { type: newType, pins }, "visual");
+        } else {
+          this.state.updateConnector(cid, { type: newType }, "visual");
+        }
+      });
+    }
     onFieldChange("#conn-orient", "orientation", v => parseInt(v));
     onFieldChange("#conn-label-style", "label_style");
     onFieldChange("#conn-desc", "description");
@@ -322,19 +339,31 @@ export class ConnectorPanel {
       });
     }
 
+    // A custom drag type marks our own pin-reorder drags, so dropping arbitrary
+    // external text/files onto a pin row can't be parsed as an index and
+    // silently reorder a pin (parseInt of stray text was NaN -> spliced pin 0).
+    const PIN_DND = "application/x-pinconnect-pin";
     this.container.querySelectorAll(".pin-drag-handle").forEach(el => {
       el.addEventListener("dragstart", (e) => {
+        e.dataTransfer.setData(PIN_DND, el.dataset.idx);
         e.dataTransfer.setData("text/plain", el.dataset.idx);
         e.dataTransfer.effectAllowed = "move";
       });
     });
 
     this.container.querySelectorAll(".pin-row").forEach(row => {
-      row.addEventListener("dragover", (e) => { e.preventDefault(); e.dataTransfer.dropEffect = "move"; });
+      row.addEventListener("dragover", (e) => {
+        if (![...e.dataTransfer.types].includes(PIN_DND)) return; // not our drag
+        e.preventDefault(); e.dataTransfer.dropEffect = "move";
+      });
       row.addEventListener("drop", (e) => {
+        const raw = e.dataTransfer.getData(PIN_DND);
+        if (raw === "") return; // not a pin-reorder drag
         e.preventDefault();
-        const from = parseInt(e.dataTransfer.getData("text/plain"));
-        const to = parseInt(row.dataset.idx);
+        const from = parseInt(raw, 10);
+        const to = parseInt(row.dataset.idx, 10);
+        const c = this.state.getConnector(cid);
+        if (!c || !Number.isInteger(from) || from < 0 || from >= c.pins.length) return;
         if (from !== to) this.state.reorderPins(cid, from, to, "visual");
       });
     });

--- a/pinout_design/js/main.js
+++ b/pinout_design/js/main.js
@@ -186,17 +186,20 @@ async function init() {
       if (document.activeElement?.tagName === "INPUT" || document.activeElement?.tagName === "TEXTAREA") return;
       state.removeConnector(state.selectedConnectorId, "visual");
     }
-    if (e.key === "s" && (e.ctrlKey || e.metaKey)) {
+    // Normalize the letter: with Shift held (or Caps Lock), e.key for a letter
+    // is uppercase, so `e.key === "z"` never matched for Ctrl+Shift+Z (redo).
+    const key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+    if (key === "s" && (e.ctrlKey || e.metaKey)) {
       e.preventDefault();
       document.getElementById("save-toml").click();
     }
-    if (e.key === "z" && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
+    if (key === "z" && (e.ctrlKey || e.metaKey) && !e.shiftKey) {
       e.preventDefault();
       state.undo();
       editorPanel._syncFromState();
     }
-    if ((e.key === "y" && (e.ctrlKey || e.metaKey)) ||
-        (e.key === "z" && (e.ctrlKey || e.metaKey) && e.shiftKey)) {
+    if ((key === "y" && (e.ctrlKey || e.metaKey)) ||
+        (key === "z" && (e.ctrlKey || e.metaKey) && e.shiftKey)) {
       e.preventDefault();
       state.redo();
       editorPanel._syncFromState();

--- a/pinout_design/js/toml-io.js
+++ b/pinout_design/js/toml-io.js
@@ -113,12 +113,28 @@ function parseTomlValue(val, lineNum) {
   if (val.startsWith("[")) {
     return parseInlineArray(val, lineNum);
   }
-  // Number (float)
-  if (val.includes(".") && !isNaN(Number(val))) return parseFloat(val);
-  // Number (int)
-  if (/^-?\d+$/.test(val)) return parseInt(val, 10);
+  // Number — accept the forms tomllib does (was stricter, so valid TOML like
+  // 1_000, +90, 1e3, 0xFF flagged a false parse error in the editor).
+  const num = parseTomlNumber(val);
+  if (num !== undefined) return num;
 
   throw new TomlParseError(`Cannot parse value: ${val}`, lineNum);
+}
+
+// Parse a TOML numeric value, or return undefined if it isn't one. Covers the
+// forms tomllib accepts: optional +/- sign, digit-group underscores, decimals,
+// exponents, hex/octal/binary integers, and inf/nan.
+function parseTomlNumber(val) {
+  const special = val.match(/^([+-]?)(inf|nan)$/);
+  if (special) return special[2] === "nan" ? NaN : (special[1] === "-" ? -Infinity : Infinity);
+  if (/^0x[0-9A-Fa-f](_?[0-9A-Fa-f])*$/.test(val)) return parseInt(val.slice(2).replace(/_/g, ""), 16);
+  if (/^0o[0-7](_?[0-7])*$/.test(val)) return parseInt(val.slice(2).replace(/_/g, ""), 8);
+  if (/^0b[01](_?[01])*$/.test(val)) return parseInt(val.slice(2).replace(/_/g, ""), 2);
+  if (/^[+-]?\d(_?\d)*(\.\d(_?\d)*)?([eE][+-]?\d(_?\d)*)?$/.test(val)) {
+    const clean = val.replace(/_/g, "");
+    return /[.eE]/.test(clean) ? parseFloat(clean) : parseInt(clean, 10);
+  }
+  return undefined;
 }
 
 function parseInlineArray(val, lineNum) {

--- a/pinout_embed/pinout_embed.py
+++ b/pinout_embed/pinout_embed.py
@@ -103,10 +103,15 @@ class PinoutTreeprocessor(Treeprocessor):
             existing = img.get("class")
             img.set("class", f"{existing} {EMBED_CLASS}".strip() if existing else EMBED_CLASS)
 
-            # Move alt text into title (screen-reader / tooltip)
-            alt = img.get("alt", "")
-            if alt:
-                img.set("title", alt)
+            # iframes have no alt; give it a title (tooltip / accessible name).
+            # Prefer an explicit Markdown image title -- ![alt](src "title") --
+            # and only fall back to the alt text, instead of always clobbering
+            # the title with alt.
+            if not img.get("title"):
+                alt = img.get("alt", "")
+                if alt:
+                    img.set("title", alt)
+            if "alt" in img.attrib:
                 del img.attrib["alt"]
 
             # Clean up image-only attributes

--- a/pinout_gen/pinout_gen/config.py
+++ b/pinout_gen/pinout_gen/config.py
@@ -104,6 +104,16 @@ def _require(table: dict, key: str, ctx: str):
         raise ValueError(f"{ctx}: missing required key '{key}'") from None
 
 
+# Enum-like fields: an unlisted value used to silently change the drawing
+# (label_style/style fell through to a default) or crash deep in rendering
+# (pinout_side -> sides.index ValueError). Validate them at load time instead.
+_LABEL_STYLES = frozenset({"staggered", "staircase", "flat"})
+_BODY_STYLES = frozenset({
+    "box", "latch", "grid", "header-male", "screw-terminal", "barrier", "button", "xt30",
+})
+_PINOUT_SIDES = frozenset({"bottom", "left", "top", "right"})
+
+
 def load_board(path: Path) -> Board:
     try:
         with open(path, "rb") as f:
@@ -160,14 +170,23 @@ def load_board(path: Path) -> Board:
                 color=p.get("color", "#888888"), row=p.get("row", 1))
             for j, p in enumerate(c.get("pin", []))
         ]
+        orientation = c.get("orientation", 0)
+        if isinstance(orientation, bool) or not isinstance(orientation, (int, float)) \
+                or orientation % 90 != 0:
+            raise ValueError(f"{ctx}: orientation must be a multiple of 90 (got {orientation!r})")
+        label_style = c.get("label_style", "staggered")
+        if label_style not in _LABEL_STYLES:
+            raise ValueError(
+                f"{ctx}: label_style must be one of {sorted(_LABEL_STYLES)} (got {label_style!r})"
+            )
         board.connectors.append(Connector(
             id=cid,
             name=_require(c, "name", ctx), type=_require(c, "type", ctx), pins=pins,
             x1=_require(c, "x1", ctx), y1=_require(c, "y1", ctx),
             x2=_require(c, "x2", ctx), y2=_require(c, "y2", ctx),
-            orientation=c.get("orientation", 0),
+            orientation=orientation,
             description=c.get("description", ""),
-            label_style=c.get("label_style", "staggered"),
+            label_style=label_style,
             symbol=c.get("symbol", ""),
         ))
     return board
@@ -203,9 +222,21 @@ def load_connector_type(path: Path) -> ConnectorType:
                 f"{path.name}: [geometry] '{k}' must be {target.__name__}, got {v!r}"
             ) from None
 
+    style = info.get("style", "box")
+    if style not in _BODY_STYLES:
+        raise ValueError(
+            f"{path.name}: unknown connector style {style!r}; valid: {sorted(_BODY_STYLES)}"
+        )
+    for side_key in ("pinout_side", "row2_pinout_side"):
+        if side_key in geo_kwargs and geo_kwargs[side_key] not in _PINOUT_SIDES:
+            raise ValueError(
+                f"{path.name}: [geometry] {side_key} must be one of "
+                f"{sorted(_PINOUT_SIDES)} (got {geo_kwargs[side_key]!r})"
+            )
+
     return ConnectorType(
         name=_require(info, "name", f"{path.name} [connector]"),
-        style=info.get("style", "box"),
+        style=style,
         geometry=ConnectorGeometry(**geo_kwargs),
     )
 

--- a/pinout_gen/pinout_gen/renderer.py
+++ b/pinout_gen/pinout_gen/renderer.py
@@ -942,8 +942,7 @@ body{{display:flex;height:100%;overflow:hidden}}
 const C={data};
 const pw=document.getElementById('pw'),tt=document.getElementById('tt'),
       sb=document.getElementById('sb'),sbBtn=document.getElementById('sb-btn');
-let aId=null,pinned=false,isTouch=false;
-document.addEventListener('touchstart',function(){{isTouch=true}},{{once:true,passive:true}});
+let aId=null,pinned=false;
 /* When the list is stacked below the board, animate its height (expand down /
    shrink up) instead of snapping.  Embedded, the iframe auto-height tracks the
    animating body height frame-by-frame. */
@@ -966,10 +965,12 @@ function toggleSb(){{
     sbEnd(()=>{{sb.classList.add('hid');sb.style.height='';sb.style.transition='';sb.style.overflow=''}});
   }}
 }}
-sbBtn.addEventListener('click',e=>{{e.stopPropagation();toggleSb();
-  if(aId){{const el=hs(aId);if(el)setTimeout(()=>pos(el),0)}}}});
-function hs(id){{return document.querySelector(`.hs[data-id="${{id}}"]`)}}
-function li(id){{return document.querySelector(`.cl-i[data-id="${{id}}"]`)}}
+sbBtn.addEventListener('click',e=>{{e.stopPropagation();toggleSb();reflow();}});
+/* Match by data-id in JS rather than a `[data-id="..."]` selector, so an id
+   containing a quote or backslash can't produce an invalid selector (which
+   throws and kills hover/click for that connector). */
+function hs(id){{return [...document.querySelectorAll('.hs')].find(e=>e.dataset.id===id)||null}}
+function li(id){{return [...document.querySelectorAll('.cl-i')].find(e=>e.dataset.id===id)||null}}
 function mark(id){{const h=hs(id),l=li(id);if(h)h.classList.add('active');if(l)l.classList.add('active')}}
 function unmark(){{document.querySelectorAll('.hs.active,.cl-i.active').forEach(e=>e.classList.remove('active'))}}
 function esc(s){{return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;')
@@ -1018,15 +1019,15 @@ function pos(el){{
 }}
 document.querySelectorAll('.hs').forEach(el=>{{
   const id=el.dataset.id;
-  el.addEventListener('mouseenter',()=>{{if(!isTouch&&!pinned){{mark(id);show(id,el)}}}});
-  el.addEventListener('mouseleave',()=>{{if(!isTouch&&!pinned){{unmark();hide()}}}});
+  el.addEventListener('pointerenter',e=>{{if(e.pointerType!=='touch'&&!pinned){{mark(id);show(id,el)}}}});
+  el.addEventListener('pointerleave',e=>{{if(e.pointerType!=='touch'&&!pinned){{unmark();hide()}}}});
   el.addEventListener('click',e=>{{e.stopPropagation();if(pinned&&aId===id){{hide();return}}
     hide();pinned=true;mark(id);show(id,el)}});
 }});
 document.querySelectorAll('.cl-i').forEach(el=>{{
   const id=el.dataset.id;
-  el.addEventListener('mouseenter',()=>{{if(!isTouch&&!pinned){{const h=hs(id);if(h){{mark(id);show(id,h)}}}}}});
-  el.addEventListener('mouseleave',()=>{{if(!isTouch&&!pinned){{unmark();hide()}}}});
+  el.addEventListener('pointerenter',e=>{{if(e.pointerType!=='touch'&&!pinned){{const h=hs(id);if(h){{mark(id);show(id,h)}}}}}});
+  el.addEventListener('pointerleave',e=>{{if(e.pointerType!=='touch'&&!pinned){{unmark();hide()}}}});
   el.addEventListener('click',e=>{{e.stopPropagation();const h=hs(id);if(!h)return;
     if(pinned&&aId===id){{hide();return}}hide();pinned=true;mark(id);show(id,h)}});
 }});
@@ -1036,6 +1037,9 @@ document.addEventListener('click',e=>{{
 document.querySelectorAll('.hs').forEach(el=>{{el.classList.add('pulse');setTimeout(()=>el.classList.remove('pulse'),2000)}});
 function reflow(){{if(aId){{const el=hs(aId);if(el)pos(el)}}}}
 window.addEventListener('resize',reflow);
+/* Re-fit a pinned tooltip once the sidebar's show/hide transition settles the
+   board layout -- the immediate reflow above runs before the .2s transition. */
+sb.addEventListener('transitionend',reflow);
 /* The board also resizes without a window resize (sidebar toggle, iframe
    auto-height, container reflow) -- re-fit the tooltip whenever it does. */
 if(window.ResizeObserver){{try{{new ResizeObserver(reflow).observe(pw)}}catch(e){{}}}}

--- a/pinout_gen/pinout_gen/renderer.py
+++ b/pinout_gen/pinout_gen/renderer.py
@@ -688,7 +688,10 @@ def _render_behavior_css(theme: Theme) -> str:
             f"@media(max-width:{b.sidebar_stack_breakpoint}px){{"
             "html,body{height:auto}"
             "body{overflow:visible;flex-direction:column;padding-bottom:8px}"
-            ".bd{flex:none;height:auto;min-height:0}"
+            # overflow:visible so a tooltip taller than the (now short) board
+            # isn't clipped at the board's bottom edge, where the stacked list
+            # begins -- clipped tooltips read as the list overlapping them.
+            ".bd{flex:none;height:auto;min-height:0;overflow:visible}"
             ".pw img{max-height:none}"
             ".sb{width:auto;max-width:none;height:auto;max-height:none;overflow:hidden;flex:none;margin:0 8px}"
             ".sb.hid{display:none}"
@@ -835,10 +838,11 @@ body{{display:flex;height:100%;overflow:hidden}}
 .tt-d{{font-size:calc(12.5px*var(--font-scale));color:var(--desc-color);margin-top:10px;padding-top:8px;
   border-top:1px solid var(--divider);line-height:1.5}}
 .bb{{position:absolute;bottom:10px;left:50%;transform:translateX(-50%);
+  max-width:calc(100% - 20px);
   background:var(--tip-bg);color:var(--type-color);border:1px solid var(--tip-border);
   padding:7px 18px;border-radius:12px;font-size:calc(12px*var(--font-scale));font-family:var(--ui-font);
-  box-shadow:0 2px 8px var(--tip-shadow);
-  display:flex;align-items:center;gap:8px;white-space:nowrap}}
+  box-shadow:0 2px 8px var(--tip-shadow);text-align:center;
+  display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:4px 8px}}
 .bb a{{color:var(--text);text-decoration:none;font-weight:500}}
 .bb a:hover{{text-decoration:underline}}
 .sb-btn{{position:absolute;right:10px;top:10px;z-index:600;width:36px;height:36px;


### PR DESCRIPTION
Hopefully the last big PR with a bunch of bug fixes. All known bugs are now fixed.
This PR:
- Fixes some remaining touch/click bugs on the rendered html
- Fixes a bug causing tooltips to get covered by the bottom connector list feature introduced with teming
- Bottom pill with hover/click hint and PinConnect attribution now wraps instead of being wider than the screen
- Adds CTRL + SHIFT + Z as a redo button to pinout designer
- Fixes known remaining bugs only present in some edge-cases in pinout designer
- Improves how pinout-gen handles bad (typo'd) values in board TOML
- Pinout-embed now uses pinout titles for accessible names
- Documents "button" missing "connector" (not really a connector, but it's the best way to highlight it) type